### PR TITLE
Implement computer and first time value calculator in edit entries

### DIFF
--- a/src/redux/reducers/siloDomainData/editEntries.js
+++ b/src/redux/reducers/siloDomainData/editEntries.js
@@ -93,10 +93,10 @@ export const editEntriesSetEntriesAction = ({ leadId, entryActions }) => ({
     leadId,
 });
 
-export const editEntriesUpdateEntriesBulkAction = ({ leadId, data }) => ({
+export const editEntriesUpdateEntriesBulkAction = ({ leadId, bulkData }) => ({
     type: EEB__UPDATE_ENTRIES_BULK,
     leadId,
-    data,
+    bulkData,
 });
 
 export const editEntriesClearEntriesAction = ({ leadId }) => ({
@@ -182,18 +182,18 @@ const setEntries = (state, action) => {
 };
 
 const updateEntriesBulk = (state, action) => {
-    const { leadId, data } = action;
+    const { leadId, bulkData } = action;
     const {
         editEntries: { [leadId]: { entries = [] } = {} } = {},
     } = state;
 
-    if (entries.length === 0 || Object.keys(data).length === 0) {
+    if (entries.length === 0 || Object.keys(bulkData).length === 0) {
         return state;
     }
 
-    const entriesSettings = Object.keys(data).reduce(
+    const entriesSettings = Object.keys(bulkData).reduce(
         (acc, key) => {
-            const { color } = data[key];
+            const { localData = {}, data = {} } = bulkData[key];
 
             const entryIndex = entries.findIndex(
                 entry => entryAccessor.key(entry) === key,
@@ -201,7 +201,10 @@ const updateEntriesBulk = (state, action) => {
 
             acc[entryIndex] = { $auto: {
                 localData: { $auto: {
-                    color: { $set: color },
+                    $merge: localData,
+                } },
+                data: { $auto: {
+                    $merge: data,
                 } },
             } };
 

--- a/src/redux/selectors/siloDomainData/editEntries.js
+++ b/src/redux/selectors/siloDomainData/editEntries.js
@@ -1,16 +1,7 @@
 import { createSelector } from 'reselect';
 
 import {
-    dateCondition,
-    timeCondition,
-    greaterThanOrEqualToCondition,
-    lessThanOrEqualToCondition,
-} from '#rsci/Faram';
-
-import {
-    isTruthy,
     listToMap,
-    decodeDate,
     compareNumber,
 } from '#rsu/common';
 import {
@@ -23,6 +14,9 @@ import {
     projectsSelector,
     leadIdFromRoute,
 } from '../domainData';
+
+import getSchemaForWidget from './editEntriesSchema';
+import getComputeSchemaForWidget from './editEntriesComputeSchema';
 
 const emptyObject = {};
 const emptyArray = [];
@@ -112,66 +106,6 @@ export const editEntriesWidgetsSelector = createSelector(
     analysisFramework => analysisFramework.widgets || emptyArray,
 );
 
-const getSchemaForWidget = (widget) => {
-    switch (widget.widgetId) {
-        case 'dateWidget': {
-            return {
-                fields: {
-                    value: [dateCondition],
-                },
-            };
-        }
-        case 'timeWidget': {
-            return {
-                fields: {
-                    value: [timeCondition],
-                },
-            };
-        }
-        case 'dateRangeWidget': {
-            return {
-                validation: ({ fromValue, toValue } = {}) => {
-                    const errors = [];
-                    if (fromValue && toValue && decodeDate(fromValue) > decodeDate(toValue)) {
-                        // FIXME: use strings
-                        errors.push('Invalid date range');
-                    }
-                    return errors;
-                },
-                fields: {
-                    fromValue: [dateCondition],
-                    toValue: [dateCondition],
-                },
-            };
-        }
-        case 'numberWidget': {
-            const {
-                properties: {
-                    data: {
-                        minValue,
-                        maxValue,
-                    } = {},
-                } = {},
-            } = widget;
-
-            const validations = [];
-            if (isTruthy(minValue)) {
-                validations.push(greaterThanOrEqualToCondition(minValue));
-            }
-            if (isTruthy(maxValue)) {
-                validations.push(lessThanOrEqualToCondition(maxValue));
-            }
-            return {
-                fields: {
-                    value: validations,
-                },
-            };
-        }
-        default:
-            return [];
-    }
-};
-
 export const editEntriesSchemaSelector = createSelector(
     editEntriesWidgetsSelector,
     (widgets) => {
@@ -187,6 +121,29 @@ export const editEntriesSchemaSelector = createSelector(
                     data: getSchemaForWidget(widget),
                 },
             };
+        });
+
+        return schema;
+    },
+);
+
+export const editEntriesComputeSchemaSelector = createSelector(
+    editEntriesWidgetsSelector,
+    (widgets) => {
+        const schema = {
+            fields: {
+                // put fields here
+            },
+        };
+        widgets.forEach((widget) => {
+            const schemaForWidget = getComputeSchemaForWidget(widget);
+            if (schemaForWidget) {
+                schema.fields[widget.id] = {
+                    fields: { data: { fields: {
+                        value: schemaForWidget,
+                    } } },
+                };
+            }
         });
 
         return schema;

--- a/src/redux/selectors/siloDomainData/editEntriesComputeSchema.js
+++ b/src/redux/selectors/siloDomainData/editEntriesComputeSchema.js
@@ -4,10 +4,13 @@ const getComputeSchemaForWidget = (widget) => {
 
     const { properties: { data: widgetData = {} } = {} } = widget;
     switch (widget.widgetId) {
+        case 'scaleWidget': {
+            const { defaultScaleUnit } = widgetData;
+            return defaultScaleUnit && (
+                (a, w, d, v) => (v || defaultScaleUnit)
+            );
+        }
         default:
-            // If we do not compute anything for the widget,
-            // we return nothing/undefined
-            // so that no compute schema is set.
             return undefined;
     }
 };

--- a/src/redux/selectors/siloDomainData/editEntriesComputeSchema.js
+++ b/src/redux/selectors/siloDomainData/editEntriesComputeSchema.js
@@ -1,0 +1,15 @@
+const getComputeSchemaForWidget = (widget) => {
+    // Each schema is a function of format:
+    // (attributes, widget, data, value) => newValue
+
+    const { properties: { data: widgetData = {} } = {} } = widget;
+    switch (widget.widgetId) {
+        default:
+            // If we do not compute anything for the widget,
+            // we return nothing/undefined
+            // so that no compute schema is set.
+            return undefined;
+    }
+};
+
+export default getComputeSchemaForWidget;

--- a/src/redux/selectors/siloDomainData/editEntriesSchema.js
+++ b/src/redux/selectors/siloDomainData/editEntriesSchema.js
@@ -1,0 +1,74 @@
+import {
+    dateCondition,
+    timeCondition,
+    greaterThanOrEqualToCondition,
+    lessThanOrEqualToCondition,
+} from '#rsci/Faram';
+
+import {
+    isTruthy,
+    decodeDate,
+} from '#rsu/common';
+
+const getSchemaForWidget = (widget) => {
+    switch (widget.widgetId) {
+        case 'dateWidget': {
+            return {
+                fields: {
+                    value: [dateCondition],
+                },
+            };
+        }
+        case 'timeWidget': {
+            return {
+                fields: {
+                    value: [timeCondition],
+                },
+            };
+        }
+        case 'dateRangeWidget': {
+            return {
+                validation: ({ fromValue, toValue } = {}) => {
+                    const errors = [];
+                    if (fromValue && toValue && decodeDate(fromValue) > decodeDate(toValue)) {
+                        // FIXME: use strings
+                        errors.push('Invalid date range');
+                    }
+                    return errors;
+                },
+                fields: {
+                    fromValue: [dateCondition],
+                    toValue: [dateCondition],
+                },
+            };
+        }
+        case 'numberWidget': {
+            const {
+                properties: {
+                    data: {
+                        minValue,
+                        maxValue,
+                    } = {},
+                } = {},
+            } = widget;
+
+            const validations = [];
+            if (isTruthy(minValue)) {
+                validations.push(greaterThanOrEqualToCondition(minValue));
+            }
+            if (isTruthy(maxValue)) {
+                validations.push(lessThanOrEqualToCondition(maxValue));
+            }
+            return {
+                fields: {
+                    value: validations,
+                },
+            };
+        }
+        default:
+            return [];
+    }
+};
+
+
+export default getSchemaForWidget;

--- a/src/views/EditEntries/WidgetFaram/index.js
+++ b/src/views/EditEntries/WidgetFaram/index.js
@@ -24,6 +24,7 @@ const propTypes = {
     entry: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     widgets: PropTypes.array, // eslint-disable-line react/forbid-prop-types
     schema: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    computeSchema: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     widgetType: PropTypes.string.isRequired,
     pending: PropTypes.bool,
 
@@ -40,6 +41,7 @@ const defaultProps = {
     widgets: [],
     onChange: () => {},
     schema: {},
+    computeSchema: {},
     actionComponent: undefined,
 };
 
@@ -243,6 +245,7 @@ export default class WidgetFaram extends React.PureComponent {
             widgets,
             className: classNameFromProps,
             schema,
+            computeSchema,
             pending,
         } = this.props;
 
@@ -262,6 +265,7 @@ export default class WidgetFaram extends React.PureComponent {
                 className={className}
                 onChange={this.handleChange}
                 schema={schema}
+                computeSchema={computeSchema}
                 value={attributes}
                 error={error}
                 disabled={pending}

--- a/src/views/EditEntries/entryColorCalculator.js
+++ b/src/views/EditEntries/entryColorCalculator.js
@@ -37,7 +37,7 @@ const calculateMatrix2dColor = (value, widgetData) => {
     return color;
 };
 
-const calculateEntryData = (values = {}, analysisFramework) => {
+const calculateEntryColor = (values = {}, analysisFramework) => {
     let color;
 
     Object.keys(values).forEach((widgetId) => {
@@ -73,7 +73,7 @@ const calculateEntryData = (values = {}, analysisFramework) => {
         }
     });
 
-    return { color };
+    return color;
 };
 
-export default calculateEntryData;
+export default calculateEntryColor;

--- a/src/views/EditEntries/entryDataCalculator.js
+++ b/src/views/EditEntries/entryDataCalculator.js
@@ -1,3 +1,5 @@
+import update from '#rsu/immutable-update';
+
 const emptyObject = {};
 
 const calculateMatrix1dColor = (value, widgetData) => {
@@ -93,15 +95,27 @@ export const calculateFirstTimeAttributes = (
                 data: widgetData = {},
             } = {},
         } = widget;
+
         let value;
 
-        if (widgetId === 'dateWidget' && widgetData.informationDateSelected) {
-            value = lead.publishedOn;
-        }
+        // Calculate first time attribute for each widget
+        if (widgetId === 'dateWidget') {
+            if (widgetData.informationDateSelected) {
+                value = lead.publishedOn;
+            }
+        } /* else if (widgetId === 'nextWidget') { ... } */
 
         if (value) {
-            acc[widget.id] = { data: { value } };
+            const settings = {
+                [widget.id]: { $auto: {
+                    data: { $auto: {
+                        value: { $set: value },
+                    } },
+                } },
+            };
+            return update(acc, settings);
         }
+
         return acc;
     }, attributes,
 );

--- a/src/views/EditEntries/entryDataCalculator.js
+++ b/src/views/EditEntries/entryDataCalculator.js
@@ -37,10 +37,10 @@ const calculateMatrix2dColor = (value, widgetData) => {
     return color;
 };
 
-const calculateEntryColor = (values = {}, analysisFramework) => {
+export const calculateEntryColor = (attributes = {}, analysisFramework) => {
     let color;
 
-    Object.keys(values).forEach((widgetId) => {
+    Object.keys(attributes).forEach((widgetId) => {
         if (color) {
             return;
         }
@@ -53,7 +53,7 @@ const calculateEntryColor = (values = {}, analysisFramework) => {
             return;
         }
 
-        const attributeValue = values[widgetId].data.value;
+        const attributeValue = attributes[widgetId].data.value;
         const widgetData = widget.properties.data;
         if (!attributeValue || !widgetData) {
             return;
@@ -76,4 +76,32 @@ const calculateEntryColor = (values = {}, analysisFramework) => {
     return color;
 };
 
-export default calculateEntryColor;
+export const calculateFirstTimeAttributes = (
+    attributes = {},
+    analysisFramework,
+    lead,
+) => analysisFramework.widgets.reduce(
+    (acc, widget) => {
+        // Ignore the attributes for widgets which are already set
+        if (acc[widget.id]) {
+            return acc;
+        }
+
+        const {
+            widgetId,
+            properties: {
+                data: widgetData = {},
+            } = {},
+        } = widget;
+        let value;
+
+        if (widgetId === 'dateWidget' && widgetData.informationDateSelected) {
+            value = lead.publishedOn;
+        }
+
+        if (value) {
+            acc[widget.id] = { data: { value } };
+        }
+        return acc;
+    }, attributes,
+);

--- a/src/views/EditEntries/index.js
+++ b/src/views/EditEntries/index.js
@@ -30,6 +30,7 @@ import {
     editEntriesEntriesSelector,
     editEntriesLeadSelector,
     editEntriesSchemaSelector,
+    editEntriesComputeSchemaSelector,
     editEntriesStatusesSelector,
 
     editEntriesAddEntryAction,
@@ -56,7 +57,10 @@ import EditEntryDataRequest from './requests/EditEntryDataRequest';
 import EditEntryDeleteRequest from './requests/EditEntryDeleteRequest';
 import EditEntrySaveRequest from './requests/EditEntrySaveRequest';
 
-import calculateEntryColor from './entryColorCalculator';
+import {
+    calculateEntryColor,
+    calculateFirstTimeAttributes,
+} from './entryDataCalculator';
 import Overview from './Overview';
 import Listing from './List';
 
@@ -69,6 +73,7 @@ const propTypes = {
     leadId: PropTypes.number.isRequired,
     projectId: PropTypes.number.isRequired,
     schema: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    computeSchema: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     statuses: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 
     addEntry: PropTypes.func.isRequired,
@@ -94,6 +99,7 @@ const defaultProps = {
     entries: [],
     statuses: {},
     schema: {},
+    computeSchema: {},
 };
 
 const mapStateToProps = state => ({
@@ -103,6 +109,7 @@ const mapStateToProps = state => ({
     leadId: leadIdFromRoute(state),
     projectId: projectIdFromRoute(state),
     schema: editEntriesSchemaSelector(state),
+    computeSchema: editEntriesComputeSchemaSelector(state),
     statuses: editEntriesStatusesSelector(state),
     routeUrl: routeUrlSelector(state),
 });
@@ -154,6 +161,7 @@ export default class EditEntries extends React.PureComponent {
                         onExcerptChange={this.handleExcerptChange}
                         onExcerptCreate={this.handleExcerptCreate}
                         schema={this.props.schema}
+                        computeSchema={this.props.computeSchema}
                     />
                 ),
                 wrapContainer: true,
@@ -171,6 +179,7 @@ export default class EditEntries extends React.PureComponent {
                         onExcerptChange={this.handleExcerptChange}
                         onExcerptCreate={this.handleExcerptCreate}
                         schema={this.props.schema}
+                        computeSchema={this.props.computeSchema}
                     />
                 ),
                 wrapContainer: true,
@@ -240,9 +249,8 @@ export default class EditEntries extends React.PureComponent {
             const bulkData = entries.reduce((acc, entry) => {
                 const entryKey = entryAccessor.key(entry);
                 acc[entryKey] = { localData: {} };
-                acc[entryKey].localData.color = calculateEntryColor(
+                acc[entryKey].localData.color = this.calculateEntryColor(
                     entryAccessor.dataAttributes(entry),
-                    analysisFramework,
                 );
                 return acc;
             }, {});
@@ -279,6 +287,18 @@ export default class EditEntries extends React.PureComponent {
         this.saveRequestCoordinator.stop();
     }
 
+    // Calculations
+    calculateFirstTimeAttributes = attributes => calculateFirstTimeAttributes(
+        attributes,
+        this.props.analysisFramework,
+        this.props.lead,
+    )
+
+    calculateEntryColor = attributes => calculateEntryColor(
+        attributes,
+        this.props.analysisFramework,
+    )
+
     // APIS
 
     handleExcerptChange = ({ type, value }, entryKey) => {
@@ -302,6 +322,7 @@ export default class EditEntries extends React.PureComponent {
                 analysisFramework: this.props.analysisFramework.id,
                 excerptType: type,
                 excerptValue: value,
+                attributes: this.calculateFirstTimeAttributes({}),
             },
         });
     }
@@ -326,7 +347,9 @@ export default class EditEntries extends React.PureComponent {
             [...faramElementName].reverse().forEach((key) => {
                 attributes = { [key]: attributes };
             });
-            const color = calculateEntryColor(attributes, analysisFramework);
+
+            attributes = this.calculateFirstTimeAttributes(attributes);
+            const color = this.calculateEntryColor(attributes);
 
             this.props.addEntry({
                 leadId: this.props.leadId,
@@ -342,8 +365,9 @@ export default class EditEntries extends React.PureComponent {
         } else if (entryKey === undefined) {
             const excerptValue = '';
             const excerptType = 'excerpt';
-            const attributes = faramValues;
-            const color = calculateEntryColor(attributes, analysisFramework);
+
+            const attributes = this.calculateFirstTimeAttributes(faramValues);
+            const color = this.calculateEntryColor(attributes);
 
             this.props.addEntry({
                 leadId: this.props.leadId,
@@ -357,7 +381,7 @@ export default class EditEntries extends React.PureComponent {
                 },
             });
         } else {
-            const color = calculateEntryColor(faramValues, analysisFramework);
+            const color = this.calculateEntryColor(faramValues);
             this.props.setEntryData({
                 leadId: this.props.leadId,
                 key: entryKey,
@@ -407,7 +431,7 @@ export default class EditEntries extends React.PureComponent {
                 });
             },
             getCoordinator: () => this.saveRequestCoordinator,
-            calculateEntryColor: attrs => calculateEntryColor(attrs, this.props.analysisFramework),
+            calculateEntryColor: this.calculateEntryColor,
         });
         request.init({
             leadId: this.props.leadId,
@@ -478,6 +502,7 @@ export default class EditEntries extends React.PureComponent {
                     error: entryAccessor.error(entry),
 
                     schema: this.props.schema,
+                    computeSchema: this.props.computeSchema,
                     onChange: this.handleChange,
 
                     onValidationFailure: (errors) => {

--- a/src/views/EditEntries/requests/EditEntryDataRequest.js
+++ b/src/views/EditEntries/requests/EditEntryDataRequest.js
@@ -71,14 +71,14 @@ export default class EditEntryDataRequest extends Request {
             return;
         }
 
-        // Calculate extra data (like color) for each entry in the diff
+        // Calculate color for each entry in the diff
         diffs.forEach((acc) => {
             const { entry: { data: { attributes = {} } = {} } = {} } = acc;
-            const extraData = this.parent.calculateEntryData(
+            const color = this.parent.calculateEntryColor(
                 attributes,
                 analysisFramework,
             );
-            acc.entry.localData.color = extraData.color;
+            acc.entry.localData.color = color;
         });
 
         this.parent.setEntries({ leadId, entryActions: diffs });

--- a/src/views/EditEntries/requests/EditEntrySaveRequest.js
+++ b/src/views/EditEntries/requests/EditEntrySaveRequest.js
@@ -21,7 +21,7 @@ export default class EditEntrySaveRequest extends Request {
 
     handleSuccess = (response) => {
         const { leadId, entryKey } = this;
-        const { color } = this.parent.calculateEntryData(response.attributes);
+        const color = this.parent.calculateEntryColor(response.attributes);
         this.parent.saveEntry({
             leadId,
             entryKey,


### PR DESCRIPTION
Requirement in react-store: https://github.com/toggle-corp/react-store/pull/308

* When an entry is first created, information date is set to lead's published date in date widget
* In the computer schema, currently we only have the default value of scale widget but we can do more in future