### PR TITLE
Remove sorting from `number_of_users` from discover projects

### DIFF
--- a/src/views/DiscoverProjects/headers.js
+++ b/src/views/DiscoverProjects/headers.js
@@ -45,7 +45,6 @@ const headers = [
         key: 'number_of_users',
         title: _ts('discoverProjects.table', 'numberOfUsersTitle'),
         order: 8,
-        sortable: true,
     },
     {
         key: 'number_of_leads',


### PR DESCRIPTION
Fix for alpha bug where server freezes when querying projects with the number of users. The fix is to remove sorting from number of users column in Discover Projects page so that the server query is simpler for projects API.