### PR TITLE
Fix data format for Organigram

### DIFF
--- a/src/widgets/edit/Organigram/index.js
+++ b/src/widgets/edit/Organigram/index.js
@@ -44,7 +44,7 @@ export default class OrganigramEditWidget extends React.PureComponent {
         const {
             data: orgData,
         } = data;
-        return { data: orgData };
+        return orgData;
     };
 
     static getTitleFromFaramValues = data => data.title;
@@ -54,6 +54,7 @@ export default class OrganigramEditWidget extends React.PureComponent {
 
         const {
             title,
+
             data,
         } = props;
 
@@ -80,6 +81,7 @@ export default class OrganigramEditWidget extends React.PureComponent {
             widgetKey,
             onChange,
         } = this.props;
+
         onChange(
             widgetKey,
             OrganigramEditWidget.getDataFromFaramValues(faramValues),


### PR DESCRIPTION
- `data` object was again wrapped in `data` object