### PR TITLE
Refactor ExternalGallery to handle various error states

### DIFF
--- a/src/components/leftpanel/LeadPreview/index.js
+++ b/src/components/leftpanel/LeadPreview/index.js
@@ -51,9 +51,9 @@ export default class LeadPreview extends React.PureComponent {
                 <ExternalGallery
                     className={_cs(styles.preview, className)}
                     url={url}
+                    showUrl
                     onScreenshotCapture={this.props.handleScreenshot}
                     showScreenshot={showScreenshot}
-                    showUrl
                 />
             );
         } else if (LeadPreview.isTypeWithAttachment(type) && attachment) {

--- a/src/components/other/ExportPreview/index.js
+++ b/src/components/other/ExportPreview/index.js
@@ -125,10 +125,11 @@ export default class ExportPreview extends React.PureComponent {
                 <GalleryViewer
                     url={exportObj.file}
                     mimeType={exportObj.mimeType}
-                    // NOTE: should not this be true
+                    // NOTE: should not this be true?
                     canShowIframe={false}
-                    invalidUrlMessage={_ts('components.exportPreview', 'previewNotAvailableLabel')}
                     showUrl
+                    // eslint-disable-next-line max-len
+                    // invalidUrlMessage={_ts('components.exportPreview', 'previewNotAvailableLabel')}
                 />
             );
         }

--- a/src/components/viewer/GalleryViewer/GalleryDocs/index.js
+++ b/src/components/viewer/GalleryViewer/GalleryDocs/index.js
@@ -12,7 +12,10 @@ const propTypes = {
     className: PropTypes.string,
     docUrl: PropTypes.string,
     mimeType: PropTypes.string,
+
+    // can the docUrl be shown in iframe
     canShowIframe: PropTypes.bool,
+    // is the docUrl https
     notHttps: PropTypes.bool,
 };
 
@@ -27,46 +30,51 @@ const defaultProps = {
 /*
  * Gallery viewer component for Docs [galleryDocsMimeType]
  */
-export default class GalleryDocs extends React.PureComponent {
-    static propTypes = propTypes;
-    static defaultProps = defaultProps;
+function GalleryDocs(props) {
+    const {
+        className: classNameFromProps,
+        docUrl,
+        mimeType,
+        canShowIframe,
+        notHttps,
+    } = props;
 
-    render() {
-        const {
-            className: classNameFromProps,
-            docUrl,
-            mimeType,
-            canShowIframe,
-            notHttps,
-        } = this.props;
+    if (!docUrl) {
+        return null;
+    }
 
-        if (!docUrl) {
-            return null;
-        }
+    const className = _cs(
+        classNameFromProps,
+        'gallery-docs',
+        styles.galleryDocs,
+    );
 
-        const useGoogle = mimeType !== 'application/pdf' || !canShowIframe || notHttps;
-        const src = useGoogle
-            ? createUrlForGoogleViewer(docUrl)
-            : docUrl;
-        const sandbox = useGoogle
-            ? 'allow-scripts allow-same-origin allow-popups'
-            : undefined;
-
-        const className = _cs(
-            classNameFromProps,
-            'gallery-docs',
-            styles.galleryDocs,
-        );
-
+    // NOTE: Google also support pdf for viewing but it does not work for localhost
+    const digestablePdf = mimeType === 'application/pdf' && canShowIframe && !notHttps;
+    if (digestablePdf) {
         return (
             <div className={className}>
-                <iframe
-                    className={`doc ${styles.doc}`}
-                    title={docUrl}
-                    src={src}
-                    sandbox={sandbox}
+                <embed
+                    className={_cs('doc', styles.doc)}
+                    type="application/pdf"
+                    src={docUrl}
                 />
             </div>
         );
     }
+
+    return (
+        <div className={className}>
+            <iframe
+                className={_cs('doc', styles.doc)}
+                title={docUrl}
+                src={createUrlForGoogleViewer(docUrl)}
+                sandbox="allow-scripts allow-same-origin allow-popups"
+            />
+        </div>
+    );
 }
+GalleryDocs.propTypes = propTypes;
+GalleryDocs.defaultProps = defaultProps;
+
+export default GalleryDocs;

--- a/src/components/viewer/GalleryViewer/GalleryImage/index.js
+++ b/src/components/viewer/GalleryViewer/GalleryImage/index.js
@@ -24,34 +24,31 @@ const defaultProps = {
 /*
  * Gallery viewer component for Images [galleryImageMimeType]
  */
-export default class GalleryImage extends React.PureComponent {
-    static propTypes = propTypes;
-    static defaultProps = defaultProps;
+function GalleryImage(props) {
+    const {
+        className,
+        imageClassName,
+        imageUrl,
+    } = props;
 
-    render() {
-        const {
-            className,
-            imageClassName,
-            imageUrl,
-        } = this.props;
-
-        return (
-            <div className={_cs('gallery-image', styles.galleryImage, className)}>
-                {
-                    imageUrl ? (
-                        <img
-                            alt={_ts('components.galleryImage', 'altUser')}
-                            className={_cs('image', styles.image, imageClassName)}
-                            src={imageUrl}
-                        />
-                    ) : (
-                        <Icon
-                            className={_cs('image-alt', styles.imageAlt)}
-                            name="user"
-                        />
-                    )
-                }
-            </div>
-        );
-    }
+    return (
+        <div className={_cs('gallery-image', styles.galleryImage, className)}>
+            {imageUrl ? (
+                <img
+                    alt={_ts('components.galleryImage', 'altUser')}
+                    className={_cs('image', styles.image, imageClassName)}
+                    src={imageUrl}
+                />
+            ) : (
+                <Icon
+                    className={_cs('image-alt', styles.imageAlt)}
+                    name="user"
+                />
+            )}
+        </div>
+    );
 }
+GalleryImage.propTypes = propTypes;
+GalleryImage.defaultProps = defaultProps;
+
+export default GalleryImage;

--- a/src/components/viewer/InternalGallery/index.js
+++ b/src/components/viewer/InternalGallery/index.js
@@ -80,6 +80,7 @@ const PreviewGallery = ({
             </div>
         );
     }
+    // NOTE: error prop of GalleryViewer can also be used instead
     if (notFound) {
         return (
             <div className={_cs(className, styles.previewGallery)}>

--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -1141,7 +1141,8 @@
         "-59901057": "Ary",
         "-25520086": "This lead is in the Assessment Registry.",
         "-27768788": "Lead successfully edited.",
-        "-39063797": "Published On"
+        "-39063797": "Published On",
+        "-13339127": "We cannot currently preview this type of document."
     },
     "links": {
         "browserExtension": {
@@ -1371,7 +1372,8 @@
             "errorTitle": -35038655,
             "saveButtonTitle": -49385196,
             "screenshotButtonTitle": -7205609,
-            "viewLinkTooltip": -2224039
+            "viewLinkTooltip": -2224039,
+            "unsupportedType": -13339127
         },
         "components.internalGallery": {
             "loadingFileLabel": 1209,

--- a/src/views/LeadAdd/LeadButtons/styles.scss
+++ b/src/views/LeadAdd/LeadButtons/styles.scss
@@ -7,7 +7,6 @@
 
     .heading {
         margin: 0;
-        border-top: var(--width-separator-thin) solid var(--color-separator);
         padding: var(--spacing-medium) var(--spacing-large);
         font-size: var(--font-size-small);
         font-weight: var(--font-weight-medium);


### PR DESCRIPTION
- ErrorGallery now accepts 'error' props to show parent errors
- GalleryDocs uses embed instead of iframe for pdf