### PR TITLE
Patch entry control status change

### DIFF
--- a/src/entities/editEntries.js
+++ b/src/entities/editEntries.js
@@ -161,7 +161,7 @@ export const createEntry = ({
     key,
     serverId,
     versionId,
-    verified,
+    controlled,
     data = {},
     isPristine = false,
     hasError = false,
@@ -204,8 +204,8 @@ export const createEntry = ({
             isMarkedAsDeleted: false,
         },
         serverData: {
+            controlled: false,
             versionId: undefined,
-            verified: false,
         },
         data: {
             id: undefined, // serverId
@@ -221,8 +221,8 @@ export const createEntry = ({
             error: { $set: undefined },
         },
         serverData: {
+            controlled: { $set: controlled },
             versionId: { $set: versionId },
-            verified: { $set: verified },
             imageDetails: { $set: imageDetails },
         },
         data: {
@@ -313,7 +313,7 @@ export const createDiff = (locals, remotes, accessor = entryAccessor, create = c
             const {
                 id: remoteServerId,
                 versionId: remoteVersionId,
-                verified: remoteVerified,
+                controlled: remoteControlled,
                 clientId: remoteKey,
             } = remoteItem;
 
@@ -333,7 +333,7 @@ export const createDiff = (locals, remotes, accessor = entryAccessor, create = c
                     key: localId,
                     serverId: remoteServerId,
                     versionId: remoteVersionId,
-                    verified: remoteVerified,
+                    controlled: remoteControlled,
                     data: remoteItem,
                     isPristine: true,
                     hasError: false,
@@ -371,13 +371,13 @@ export const createDiff = (locals, remotes, accessor = entryAccessor, create = c
                 const {
                     id: remoteServerId,
                     versionId: remoteVersionId,
-                    verified: remoteVerified,
+                    controlled: remoteControlled,
                 } = remoteItem;
                 const newItem = create({
                     key: localId,
                     serverId: remoteServerId, // here
                     versionId: remoteVersionId,
-                    verified: remoteVerified,
+                    controlled: remoteControlled,
                     data: remoteItem,
                     isPristine: true,
                     hasError: false,
@@ -390,7 +390,7 @@ export const createDiff = (locals, remotes, accessor = entryAccessor, create = c
                     key: localId,
                     serverId: remoteServerId,
                     versionId: remoteVersionId,
-                    verified: remoteVerified,
+                    controlled: remoteControlled,
                     data: localValues,
                     isPristine: localPristine,
                     hasError: localError,

--- a/src/redux/reducers/siloDomainData/editEntries.js
+++ b/src/redux/reducers/siloDomainData/editEntries.js
@@ -501,7 +501,7 @@ const setEntryControlStatus = (state, action) => {
     const newAction = {
         leadId,
         entries: [entry],
-        updateVersionId: true,
+        updateVersionId: false,
     };
 
     return setEntriesControlStatus(state, newAction);
@@ -977,7 +977,6 @@ const applyToAllEntries = mode => (state, action) => {
     let iterableEntries;
     if (mode === 'all-below') {
         const entryIndex = entries.findIndex(entry => entryAccessor.key(entry) === entryKey);
-        console.warn(entryIndex);
         // set all entries before current entry to undefined
         iterableEntries = entries.map((entry, i) => (i < entryIndex ? undefined : entry));
     } else if (mode === 'all') {

--- a/src/redux/reducers/siloDomainData/entries.js
+++ b/src/redux/reducers/siloDomainData/entries.js
@@ -9,7 +9,7 @@ export const E__UPDATE_FILTER = 'siloDomainData/E__UPDATE_FILTER';
 export const E__UNSET_FILTER = 'siloDomainData/E__UNSET_FILTER';
 export const E__SET_ACTIVE_PAGE = 'siloDomainData/E__SET_ACTIVE_PAGE';
 export const E__SET_ENTRY_COMMENTS_COUNT = 'siloDomainData/E__SET_ENTRY_COMMENTS_COUNT';
-export const E__PATCH_ENTRY_CONTROl = 'siloDomainData/E__PATCH_ENTRY_CONTROl';
+export const E__PATCH_ENTRY_CONTROL = 'siloDomainData/E__PATCH_ENTRY_CONTROL';
 export const E__PATCH_ENTRY_VERIFICATION = 'siloDomainData/E__PATCH_ENTRY_VERIFICATION';
 export const E__DELETE_ENTRY = 'siloDomainData/E__DELETE_ENTRY';
 export const E__EDIT_ENTRY = 'siloDomainData/E__EDIT_ENTRY';
@@ -54,7 +54,7 @@ export const setEntriesAction = ({ projectId, entries, totalEntriesCount }) => (
 });
 
 export const patchEntryControlAction = ({ versionId, entryId, leadId, status }) => ({
-    type: E__PATCH_ENTRY_CONTROl,
+    type: E__PATCH_ENTRY_CONTROL,
     entryId,
     leadId,
     status,
@@ -518,7 +518,7 @@ const reducers = {
     [E__SET_ENTRIES]: setEntries,
     [E__SET_ENTRY_COMMENTS_COUNT]: setEntryCommentsCount,
     [E__SET_ACTIVE_PAGE]: entriesViewSetActivePage,
-    [E__PATCH_ENTRY_CONTROl]: patchEntryControl,
+    [E__PATCH_ENTRY_CONTROL]: patchEntryControl,
     [E__PATCH_ENTRY_VERIFICATION]: patchEntryVerification,
     [E__DELETE_ENTRY]: deleteEntry,
     [E__EDIT_ENTRY]: editEntry,

--- a/src/redux/selectors/siloDomainData/editEntries.js
+++ b/src/redux/selectors/siloDomainData/editEntries.js
@@ -134,6 +134,7 @@ export const editEntriesSelectedEntrySelector = createSelector(
         if (selectedEntryKey === undefined) {
             return undefined;
         }
+
         return entries.find(
             entry => entryAccessor.key(entry) === selectedEntryKey,
         );

--- a/src/schema/entries.js
+++ b/src/schema/entries.js
@@ -49,7 +49,7 @@ const entrySchema = [];
         fields: {
             analysisFramework: { type: 'uint', required: true },
 
-            image: { type: 'string' },
+            image: { type: 'number' },
             imageRaw: { type: 'string' },
             imageDetails: { type: 'imageDetails' },
             excerpt: { type: 'string' },

--- a/src/schema/entries.js
+++ b/src/schema/entries.js
@@ -49,7 +49,7 @@ const entrySchema = [];
         fields: {
             analysisFramework: { type: 'uint', required: true },
 
-            image: { type: 'number' },
+            image: { type: 'string' },
             imageRaw: { type: 'string' },
             imageDetails: { type: 'imageDetails' },
             excerpt: { type: 'string' },

--- a/src/views/EditEntries/List/WidgetFaramContainer/index.js
+++ b/src/views/EditEntries/List/WidgetFaramContainer/index.js
@@ -27,6 +27,7 @@ import {
 
     editEntriesSetSelectedEntryKeyAction,
     editEntriesMarkAsDeletedEntryAction,
+    editEntriesSetEntryControlStatusAction,
 } from '#redux';
 
 import EntryLabelBadge from '#components/general/EntryLabel';
@@ -51,6 +52,7 @@ const propTypes = {
     index: PropTypes.number.isRequired,
     entryGroups: PropTypes.array, // eslint-disable-line react/forbid-prop-types
     labels: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+    setEditEntryControl: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -70,6 +72,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     setSelectedEntryKey: params => dispatch(editEntriesSetSelectedEntryKeyAction(params)),
     markAsDeletedEntry: params => dispatch(editEntriesMarkAsDeletedEntryAction(params)),
+    setEditEntryControl: params => dispatch(editEntriesSetEntryControlStatusAction(params)),
 });
 
 const entryLabelKeySelector = d => d.labelId;
@@ -95,6 +98,7 @@ function WidgetFaramContainer(props) {
         selectedEntryKey,
         setSelectedEntryKey,
         markAsDeletedEntry,
+        setEditEntryControl,
     } = props;
 
     const [controlPending, setControlPending] = useState(false);
@@ -128,6 +132,15 @@ function WidgetFaramContainer(props) {
             value: true,
         });
     }, [markAsDeletedEntry, entry, leadId]);
+
+    const handleEntryControlChange = useCallback((controlStatus) => {
+        const entryForPatch = {
+            id: entryAccessor.serverId(entry),
+            controlled: controlStatus,
+        };
+
+        setEditEntryControl({ entry: entryForPatch, leadId });
+    }, [entry, leadId, setEditEntryControl]);
 
     const entryKey = entryAccessor.key(entry);
     const controlled = entryAccessor.controlled(entry);
@@ -183,8 +196,9 @@ function WidgetFaramContainer(props) {
                         entryId={entryAccessor.serverId(entry)}
                         projectId={lead.project}
                         value={controlled}
-                        disabled={disableControlledButton}
                         onPendingStatusChange={setControlPending}
+                        onChange={handleEntryControlChange}
+                        disabled={disableControlledButton}
                     />
                     {labels.length > 0 && (
                         <ModalButton

--- a/src/views/EditEntries/List/WidgetFaramContainer/index.js
+++ b/src/views/EditEntries/List/WidgetFaramContainer/index.js
@@ -26,7 +26,6 @@ import {
     editEntriesFilteredEntryGroupsSelector,
 
     editEntriesSetSelectedEntryKeyAction,
-    editEntriesSetEntryControlStatusAction,
     editEntriesMarkAsDeletedEntryAction,
 } from '#redux';
 
@@ -49,8 +48,6 @@ const propTypes = {
     setSelectedEntryKey: PropTypes.func.isRequired,
     leadId: PropTypes.number.isRequired,
     markAsDeletedEntry: PropTypes.func.isRequired,
-    setEntryControlStatus: PropTypes.func.isRequired,
-
     index: PropTypes.number.isRequired,
     entryGroups: PropTypes.array, // eslint-disable-line react/forbid-prop-types
     labels: PropTypes.array, // eslint-disable-line react/forbid-prop-types
@@ -72,9 +69,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     setSelectedEntryKey: params => dispatch(editEntriesSetSelectedEntryKeyAction(params)),
-    setEntryControlStatus: params => dispatch(
-        editEntriesSetEntryControlStatusAction(params),
-    ),
     markAsDeletedEntry: params => dispatch(editEntriesMarkAsDeletedEntryAction(params)),
 });
 
@@ -100,7 +94,6 @@ function WidgetFaramContainer(props) {
         labels,
         selectedEntryKey,
         setSelectedEntryKey,
-        setEntryControlStatus,
         markAsDeletedEntry,
     } = props;
 
@@ -135,16 +128,6 @@ function WidgetFaramContainer(props) {
             value: true,
         });
     }, [markAsDeletedEntry, entry, leadId]);
-
-    const handleControlStatusChange = useCallback((controlled) => {
-        const entryForPatch = {
-            id: entryAccessor.serverId(entry),
-            controlled,
-            versionId: entry.versionId,
-        };
-
-        setEntryControlStatus({ entry: entryForPatch, leadId });
-    }, [entry, setEntryControlStatus, leadId]);
 
     const entryKey = entryAccessor.key(entry);
     const controlled = entryAccessor.controlled(entry);
@@ -200,7 +183,6 @@ function WidgetFaramContainer(props) {
                         entryId={entryAccessor.serverId(entry)}
                         projectId={lead.project}
                         value={controlled}
-                        onChange={handleControlStatusChange}
                         disabled={disableControlledButton}
                         onPendingStatusChange={setControlPending}
                     />

--- a/src/views/EditEntries/Overview/index.js
+++ b/src/views/EditEntries/Overview/index.js
@@ -33,7 +33,6 @@ import {
     editEntriesSelectedEntryKeySelector,
     editEntriesFilteredEntriesSelector,
     editEntriesSetEntryCommentsCountAction,
-    editEntriesSetEntryControlStatusAction,
     editEntriesSetSelectedEntryKeyAction,
     editEntriesMarkAsDeletedEntryAction,
     fieldsMapForTabularBookSelector,
@@ -66,7 +65,6 @@ const propTypes = {
     setSelectedEntryKey: PropTypes.func.isRequired,
     markAsDeletedEntry: PropTypes.func.isRequired,
     setEntryCommentsCount: PropTypes.func.isRequired,
-    setEntryControlStatus: PropTypes.func.isRequired,
     addEntry: PropTypes.func.isRequired,
     entryGroups: PropTypes.array, // eslint-disable-line react/forbid-prop-types
     labels: PropTypes.array, // eslint-disable-line react/forbid-prop-types
@@ -100,9 +98,6 @@ const mapStateToProps = (state, props) => ({
 const mapDispatchToProps = dispatch => ({
     addEntry: params => dispatch(editEntriesAddEntryAction(params)),
     setEntryCommentsCount: params => dispatch(editEntriesSetEntryCommentsCountAction(params)),
-    setEntryControlStatus: params => dispatch(
-        editEntriesSetEntryControlStatusAction(params),
-    ),
     setSelectedEntryKey: params => dispatch(editEntriesSetSelectedEntryKeyAction(params)),
     markAsDeletedEntry: params => dispatch(editEntriesMarkAsDeletedEntryAction(params)),
 });
@@ -244,22 +239,6 @@ export default class Overview extends React.PureComponent {
         setEntryCommentsCount({ entry, leadId });
     }
 
-    handleControlChange = (controlled) => {
-        const {
-            entry: entryFromProps,
-            leadId,
-            setEntryControlStatus,
-        } = this.props;
-
-        const entry = {
-            id: entryAccessor.serverId(entryFromProps),
-            controlled,
-            versionId: entryFromProps.versionId,
-        };
-
-        setEntryControlStatus({ entry, leadId });
-    }
-
     handleEntryControlPendingChange = (entryControlPending) => {
         this.setState({ entryControlPending });
     }
@@ -349,7 +328,6 @@ export default class Overview extends React.PureComponent {
                                     entryId={entryAccessor.serverId(entry)}
                                     projectId={lead.project}
                                     value={controlled}
-                                    onChange={this.handleControlChange}
                                     onPendingStatusChange={this.handleEntryControlPendingChange}
                                     disabled={disableControlledButton}
                                 />

--- a/src/views/EditEntries/Overview/index.js
+++ b/src/views/EditEntries/Overview/index.js
@@ -36,6 +36,7 @@ import {
     editEntriesSetSelectedEntryKeyAction,
     editEntriesMarkAsDeletedEntryAction,
     fieldsMapForTabularBookSelector,
+    editEntriesSetEntryControlStatusAction,
 } from '#redux';
 import { VIEW } from '#widgets';
 
@@ -65,6 +66,7 @@ const propTypes = {
     setSelectedEntryKey: PropTypes.func.isRequired,
     markAsDeletedEntry: PropTypes.func.isRequired,
     setEntryCommentsCount: PropTypes.func.isRequired,
+    setEditEntryControl: PropTypes.func.isRequired,
     addEntry: PropTypes.func.isRequired,
     entryGroups: PropTypes.array, // eslint-disable-line react/forbid-prop-types
     labels: PropTypes.array, // eslint-disable-line react/forbid-prop-types
@@ -100,6 +102,7 @@ const mapDispatchToProps = dispatch => ({
     setEntryCommentsCount: params => dispatch(editEntriesSetEntryCommentsCountAction(params)),
     setSelectedEntryKey: params => dispatch(editEntriesSetSelectedEntryKeyAction(params)),
     markAsDeletedEntry: params => dispatch(editEntriesMarkAsDeletedEntryAction(params)),
+    setEditEntryControl: params => dispatch(editEntriesSetEntryControlStatusAction(params)),
 });
 
 @connect(mapStateToProps, mapDispatchToProps)
@@ -243,6 +246,20 @@ export default class Overview extends React.PureComponent {
         this.setState({ entryControlPending });
     }
 
+    handleEntryControlChange = (controlStatus) => {
+        const {
+            entry,
+            leadId,
+            setEditEntryControl,
+        } = this.props;
+        const entryForPatch = {
+            id: entryAccessor.serverId(entry),
+            controlled: controlStatus,
+        };
+
+        setEditEntryControl({ entry: entryForPatch, leadId });
+    }
+
     render() {
         const {
             className,
@@ -329,6 +346,7 @@ export default class Overview extends React.PureComponent {
                                     projectId={lead.project}
                                     value={controlled}
                                     onPendingStatusChange={this.handleEntryControlPendingChange}
+                                    onChange={this.handleEntryControlChange}
                                     disabled={disableControlledButton}
                                 />
                                 {labels.length > 0 && (

--- a/src/views/Entries/LeadGroupedEntries/Entry/index.js
+++ b/src/views/Entries/LeadGroupedEntries/Entry/index.js
@@ -27,7 +27,6 @@ import {
     entriesSetEntryCommentsCountAction,
     deleteEntryAction,
     editEntryAction,
-    patchEntryControlAction,
     patchEntryVerificationAction,
 } from '#redux';
 
@@ -58,7 +57,6 @@ const propTypes = {
     leadId: PropTypes.number,
     setEntryCommentsCount: PropTypes.func.isRequired,
     onEntryEdit: PropTypes.func.isRequired,
-    setEntryControl: PropTypes.func.isRequired,
     setEntryVerification: PropTypes.func.isRequired,
     // eslint-disable-next-line react/forbid-prop-types
     requests: PropTypes.object.isRequired,
@@ -102,7 +100,6 @@ const mapDispatchToProps = dispatch => ({
     setEntryCommentsCount: params => dispatch(entriesSetEntryCommentsCountAction(params)),
     onEntryDelete: params => dispatch(deleteEntryAction(params)),
     onEntryEdit: params => dispatch(editEntryAction(params)),
-    setEntryControl: params => dispatch(patchEntryControlAction(params)),
     setEntryVerification: params => dispatch(patchEntryVerificationAction(params)),
 });
 
@@ -159,24 +156,6 @@ export default class Entry extends React.PureComponent {
         };
 
         setEntryCommentsCount({ entry, projectId, leadId });
-    }
-
-    handleEntryControlChange = (controlled) => {
-        const {
-            setEntryControl,
-            entry: {
-                id: entryId,
-                versionId,
-            },
-            leadId,
-        } = this.props;
-
-        setEntryControl({
-            entryId,
-            leadId,
-            status: controlled,
-            versionId,
-        });
     }
 
     handleEntryVerificationChange = (verified, count) => {
@@ -374,7 +353,6 @@ export default class Entry extends React.PureComponent {
                                 entryId={entryId}
                                 projectId={projectId}
                                 value={controlled}
-                                onChange={this.handleEntryControlChange}
                             />
                         </div>
                         <Cloak

--- a/src/views/Entries/LeadGroupedEntries/Entry/index.js
+++ b/src/views/Entries/LeadGroupedEntries/Entry/index.js
@@ -28,6 +28,7 @@ import {
     deleteEntryAction,
     editEntryAction,
     patchEntryVerificationAction,
+    patchEntryControlAction,
 } from '#redux';
 
 import {
@@ -58,6 +59,7 @@ const propTypes = {
     setEntryCommentsCount: PropTypes.func.isRequired,
     onEntryEdit: PropTypes.func.isRequired,
     setEntryVerification: PropTypes.func.isRequired,
+    setEntryControl: PropTypes.func.isRequired,
     // eslint-disable-next-line react/forbid-prop-types
     requests: PropTypes.object.isRequired,
 };
@@ -101,6 +103,7 @@ const mapDispatchToProps = dispatch => ({
     onEntryDelete: params => dispatch(deleteEntryAction(params)),
     onEntryEdit: params => dispatch(editEntryAction(params)),
     setEntryVerification: params => dispatch(patchEntryVerificationAction(params)),
+    setEntryControl: params => dispatch(patchEntryControlAction(params)),
 });
 
 const widgetLayoutSelector = (widget) => {
@@ -179,6 +182,24 @@ export default class Entry extends React.PureComponent {
 
     handleEntryControlPendingChange = (entryControlPending) => {
         this.setState({ entryControlPending });
+    }
+
+    handleEntryControlChange = (controlStatus) => {
+        const {
+            entry: {
+                id: entryId,
+                versionId,
+            },
+            leadId,
+            setEntryControl,
+        } = this.props;
+
+        setEntryControl({
+            entryId,
+            leadId,
+            status: controlStatus,
+            versionId,
+        });
     }
 
     handleEntryDelete = () => {
@@ -353,6 +374,7 @@ export default class Entry extends React.PureComponent {
                                 entryId={entryId}
                                 projectId={projectId}
                                 value={controlled}
+                                onChange={this.handleEntryControlChange}
                             />
                         </div>
                         <Cloak

--- a/src/views/Entries/QualityControl/EntryCard/index.tsx
+++ b/src/views/Entries/QualityControl/EntryCard/index.tsx
@@ -192,17 +192,6 @@ function EntryCard(props: EntryCardProps) {
         };
     }, []);
 
-    const handleEntryControlChange = useCallback((controlled) => {
-        if (onEntryChange) {
-            const entryToPatch = {
-                ...entry,
-                controlled,
-            };
-
-            onEntryChange(entryToPatch);
-        }
-    }, [entry, onEntryChange]);
-
     const handleEntryVerificationChange = useCallback(
         (verified: boolean, verificationCount: number) => {
             if (onEntryChange) {
@@ -216,6 +205,16 @@ function EntryCard(props: EntryCardProps) {
             }
         }, [entry, onEntryChange],
     );
+
+    const handleEntryControlChange = useCallback((controlled: boolean) => {
+        if (onEntryChange) {
+            const entryToPatch = {
+                ...entry,
+                controlled,
+            };
+            onEntryChange(entryToPatch);
+        }
+    }, [entry, onEntryChange]);
 
     const entryLastChangedBy = entry?.controlledChangedByDetails?.displayName;
 
@@ -388,8 +387,8 @@ function EntryCard(props: EntryCardProps) {
                                     projectId={entry.project}
                                     entryId={entry.id}
                                     value={entry.controlled}
-                                    onChange={handleEntryControlChange}
                                     disabled={isDeleted}
+                                    onChange={handleEntryControlChange}
                                 />
                                 <EntryCommentButton entryId={entry.id} />
                                 <EntryOpenLink

--- a/src/views/Entries/QualityControl/EntryCard/index.tsx
+++ b/src/views/Entries/QualityControl/EntryCard/index.tsx
@@ -387,8 +387,8 @@ function EntryCard(props: EntryCardProps) {
                                     projectId={entry.project}
                                     entryId={entry.id}
                                     value={entry.controlled}
-                                    disabled={isDeleted}
                                     onChange={handleEntryControlChange}
+                                    disabled={isDeleted}
                                 />
                                 <EntryCommentButton entryId={entry.id} />
                                 <EntryOpenLink

--- a/src/views/Entries/QualityControl/index.tsx
+++ b/src/views/Entries/QualityControl/index.tsx
@@ -291,6 +291,7 @@ function QualityControl(props: Props) {
     useEffect(
         getEntries,
         [
+            getEntries,
             projectId,
             activePage,
             requestFilters,

--- a/src/views/Entries/index.js
+++ b/src/views/Entries/index.js
@@ -575,6 +575,7 @@ export default class Entries extends React.PureComponent {
         } else {
             window.removeEventListener('scroll', this.handleListScroll, true);
         }
+        this.startEntriesRequest();
     }
 
     handleGotoTopButtonClick = () => {


### PR DESCRIPTION
This commit updates control status for both EditEntries page and
Entries page. Previously the control status were updated only in
the respective view store.
depends on https://github.com/the-deep/server/pull/755