### PR TITLE
Add ChangePasswordModal to facilitate user password change

### DIFF
--- a/src/components/general/ChangePasswordButton/index.tsx
+++ b/src/components/general/ChangePasswordButton/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { useModalState } from '#hooks/stateManagement';
+import { IoArrowForward } from 'react-icons/io5';
+import { Button } from '@the-deep/deep-ui';
+import ChangePasswordModal, { Props as ChangePasswordModalProps } from '#components/general/ChangePasswordModal';
+import _ts from '#ts';
+
+type Props = Omit<ChangePasswordModalProps, 'onModalClose'> & {
+    className?: string;
+    disabled?: boolean;
+}
+
+function ChangePasswordButton(props: Props) {
+    const {
+        className,
+        disabled,
+        ...stakeholderModalProps
+    } = props;
+
+    const [
+        showModal,
+        ,
+        hideModal,
+        ,
+        toggleModalShow,
+    ] = useModalState(false);
+
+    return (
+        <>
+            <Button
+                className={className}
+                name={undefined}
+                variant="secondary"
+                onClick={toggleModalShow}
+                disabled={disabled}
+                actions={<IoArrowForward />}
+            >
+                {_ts('changePassword', 'title')}
+            </Button>
+            {showModal && (
+                <ChangePasswordModal
+                    {...stakeholderModalProps}
+                    onModalClose={hideModal}
+                />
+            )}
+        </>
+    );
+}
+
+export default ChangePasswordButton;

--- a/src/components/general/ChangePasswordButton/index.tsx
+++ b/src/components/general/ChangePasswordButton/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-
-import { useModalState } from '#hooks/stateManagement';
 import { IoArrowForward } from 'react-icons/io5';
 import { Button } from '@the-deep/deep-ui';
+
+import { useModalState } from '#hooks/stateManagement';
 import ChangePasswordModal, { Props as ChangePasswordModalProps } from '#components/general/ChangePasswordModal';
 import _ts from '#ts';
 
@@ -19,11 +19,9 @@ function ChangePasswordButton(props: Props) {
     } = props;
 
     const [
+        isShown,
         showModal,
-        ,
         hideModal,
-        ,
-        toggleModalShow,
     ] = useModalState(false);
 
     return (
@@ -32,13 +30,13 @@ function ChangePasswordButton(props: Props) {
                 className={className}
                 name={undefined}
                 variant="secondary"
-                onClick={toggleModalShow}
+                onClick={showModal}
                 disabled={disabled}
                 actions={<IoArrowForward />}
             >
                 {_ts('changePassword', 'title')}
             </Button>
-            {showModal && (
+            {isShown && (
                 <ChangePasswordModal
                     {...stakeholderModalProps}
                     onModalClose={hideModal}

--- a/src/components/general/ChangePasswordModal/index.tsx
+++ b/src/components/general/ChangePasswordModal/index.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback } from 'react';
+import { isDefined } from '@togglecorp/fujs';
+import {
+    useForm,
+    ObjectSchema,
+    PartialForm,
+    requiredCondition,
+    lengthGreaterThanCondition,
+    lengthSmallerThanCondition,
+} from '@togglecorp/toggle-form';
+import {
+    Button,
+    Modal,
+    TextInput,
+} from '@the-deep/deep-ui';
+import NonFieldError from '#components/ui/NonFieldError';
+import { useLazyRequest } from '#utils/request';
+import _ts from '#ts';
+import { User } from '#typings';
+
+import styles from './styles.scss';
+
+type FormType = {
+    oldPassword?: string;
+    newPassword?: string;
+    confirmPassword?: string;
+}
+
+type FormSchema = ObjectSchema<PartialForm<FormType>>;
+type FormSchemaFields = ReturnType<FormSchema['fields']>;
+
+const changePasswordSchema: FormSchema = {
+    fields: (): FormSchemaFields => ({
+        oldPassword: [requiredCondition],
+        newPassword: [
+            lengthGreaterThanCondition(4),
+            lengthSmallerThanCondition(129),
+            requiredCondition,
+        ],
+        confirmPassword: [
+            requiredCondition,
+        ],
+    }),
+    validation: (value) => {
+        if (
+            value?.confirmPassword &&
+            value?.newPassword &&
+            value.confirmPassword !== value.newPassword) {
+            return _ts('changePassword', 'passwordMismatch');
+        }
+        return undefined;
+    },
+};
+
+const defaultFormValue: PartialForm<FormType> = {};
+
+export interface Props {
+    onModalClose: () => void;
+}
+
+function ChangePasswordModal(props: Props) {
+    const {
+        onModalClose,
+    } = props;
+
+    const {
+        pristine,
+        value,
+        error,
+        onValueChange,
+        validate,
+        onErrorSet,
+    } = useForm(defaultFormValue, changePasswordSchema);
+
+    const {
+        pending,
+        trigger: changePassword,
+    } = useLazyRequest<User, Pick<FormType, 'oldPassword' | 'newPassword'>>({
+        url: 'server://users/me/change-password/',
+        method: 'POST',
+        body: ctx => ctx,
+        onSuccess: () => {
+            onModalClose();
+        },
+        onFailure: (err) => {
+            onErrorSet({ fields: { ...err.value.faramErrors } });
+        },
+        failureHeader: _ts('changePassword', 'title'),
+    });
+
+    const handleSubmitButtonClick = useCallback(() => {
+        const { errored, error: err, value: val } = validate();
+        onErrorSet(err);
+        if (!errored && isDefined(val)) {
+            changePassword({ oldPassword: val.oldPassword, newPassword: val.newPassword });
+        }
+    }, [onErrorSet, validate, changePassword]);
+
+    return (
+        <Modal
+            className={styles.changePasswordModal}
+            heading={_ts('changePassword', 'title')}
+            onCloseButtonClick={onModalClose}
+            bodyClassName={styles.modalBody}
+            footerActions={(
+                <>
+                    <Button
+                        name={undefined}
+                        variant="secondary"
+                        disabled={pristine || pending}
+                        onClick={onModalClose}
+                    >
+                        {_ts('changePassword', 'cancel')}
+                    </Button>
+                    <Button
+                        name={undefined}
+                        variant="primary"
+                        type="submit"
+                        disabled={pristine || pending}
+                        onClick={handleSubmitButtonClick}
+                    >
+                        {_ts('changePassword', 'change')}
+                    </Button>
+                </>
+            )}
+        >
+            <NonFieldError error={error} />
+            <TextInput // FIXME: use PasswordInput when availabe
+                name="oldPassword"
+                type="password"
+                label={_ts('changePassword', 'currentPassword')}
+                placeholder={_ts('changePassword', 'currentPassword')}
+                value={value.oldPassword}
+                error={error?.fields?.oldPassword}
+                disabled={pending}
+                onChange={onValueChange}
+            />
+            <TextInput // FIXME: use PasswordInput when availabe
+                name="newPassword"
+                type="password"
+                label={_ts('changePassword', 'newPassword')}
+                placeholder={_ts('changePassword', 'newPassword')}
+                value={value.newPassword}
+                error={error?.fields?.newPassword}
+                disabled={pending}
+                onChange={onValueChange}
+            />
+            <TextInput // FIXME: use PasswordInput when availabe
+                name="confirmPassword"
+                type="password"
+                label={_ts('changePassword', 'retypePassword')}
+                placeholder={_ts('changePassword', 'retypePassword')}
+                value={value.confirmPassword}
+                error={error?.fields?.confirmPassword}
+                disabled={pending}
+                onChange={onValueChange}
+            />
+        </Modal>
+    );
+}
+
+export default ChangePasswordModal;

--- a/src/newViews/MyProfile/index.tsx
+++ b/src/newViews/MyProfile/index.tsx
@@ -1,13 +1,6 @@
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
-import NonFieldError from '#components/ui/NonFieldError';
-
-import {
-    AppState,
-    LanguagePreference,
-    MultiResponse,
-} from '#typings';
 import {
     TextInput,
     SelectInput,
@@ -17,14 +10,6 @@ import {
     Button,
     List,
 } from '@the-deep/deep-ui';
-import Avatar from '#components/ui/Avatar';
-
-import _ts from '#ts';
-import {
-    activeUserSelector,
-    setUserInformationAction,
-} from '#redux';
-import { useRequest, useLazyRequest } from '#utils/request';
 import {
     ObjectSchema,
     requiredStringCondition,
@@ -33,6 +18,21 @@ import {
     arrayCondition,
     requiredCondition,
 } from '@togglecorp/toggle-form';
+
+import Avatar from '#components/ui/Avatar';
+import NonFieldError from '#components/ui/NonFieldError';
+import _ts from '#ts';
+import {
+    activeUserSelector,
+    setUserInformationAction,
+} from '#redux';
+import {
+    AppState,
+    LanguagePreference,
+    MultiResponse,
+} from '#typings';
+import { useRequest, useLazyRequest } from '#utils/request';
+import ChangePasswordButton from '#components/general/ChangePasswordButton';
 
 import styles from './styles.scss';
 
@@ -244,6 +244,9 @@ function MyProfile(props: Props & PropsFromDispatch) {
                                 error={error?.fields?.organization}
                                 label={_ts('myProfile', 'organization')}
                                 placeholder={_ts('myProfile', 'organization')}
+                            />
+                            <ChangePasswordButton
+                                className={styles.changePassword}
                             />
                         </Container>
                         <Container

--- a/src/newViews/MyProfile/styles.scss
+++ b/src/newViews/MyProfile/styles.scss
@@ -44,6 +44,10 @@
                         flex: 1;
                         background-color: var(--dui-color-foreground);
                         padding: var(--dui-spacing-extra-small) var(--dui-spacing-medium);
+
+                        .change-password {
+                            margin: var(--dui-spacing-medium);
+                        }
                     }
 
                     .preferences {

--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -1369,7 +1369,14 @@
         "-8183719471": "Organization Type",
         "-9182819349": "Personal Info",
         "-8182838101": "Preferences",
-        "-8183718381": "Platform Language"
+        "-8183718381": "Platform Language",
+        "-8128301084": "New password and retyped password doesn't match.",
+        "-919481010": "Change password",
+        "-818401818": "Change",
+        "-181814830": "Cancel",
+        "-819410810": "Current password",
+        "-819181030": "New password",
+        "-918202011": "Retype password"
     },
     "links": {
         "browserExtension": {
@@ -3920,6 +3927,15 @@
             "lastName": 152,
             "organization": 154,
             "saveMyProfile": 25
+        },
+        "changePassword": {
+            "title": -919481010,
+            "passwordMismatch": -8128301084,
+            "change": -818401818,
+            "cancel": -181814830,
+            "currentPassword": -819410810,
+            "newPassword": -819181030,
+            "retypePassword": -918202011
         }
     }
 }

--- a/src/utils/request/deep.ts
+++ b/src/utils/request/deep.ts
@@ -28,7 +28,7 @@ export interface ErrorFromServer {
 function alterResponse(errors: ErrorFromServer['errors']): Error['value']['faramErrors'] {
     const otherErrors = mapToMap(
         errors,
-        item => item,
+        item => (item === 'nonFieldErrors' ? '$internal' : item),
         item => (Array.isArray(item) ? item.join(' ') : item),
     );
     return otherErrors;

--- a/src/views/Login/index.js
+++ b/src/views/Login/index.js
@@ -98,7 +98,7 @@ function Login(props) {
                 recaptchaRef.current.reset();
             }
         },
-        onFailure: ({ value: { errorCode, faramErrors: newFaramErrors } }) => {
+        onFailure: ({ errorCode, value: { faramErrors: newFaramErrors } }) => {
             if (recaptchaRef.current && recaptchaRef.current.reset) {
                 recaptchaRef.current.reset();
             }

--- a/src/views/Register/index.js
+++ b/src/views/Register/index.js
@@ -53,7 +53,7 @@ function Register() {
                 recaptchaRef.current.reset();
             }
         },
-        onFailure: ({ value: { errorCode, faramErrors: newFaramErrors } }) => {
+        onFailure: ({ errorCode, value: { faramErrors: newFaramErrors } }) => {
             if (recaptchaRef.current && recaptchaRef.current.reset) {
                 recaptchaRef.current.reset();
             }


### PR DESCRIPTION
- Addresses #1682
- Depends on https://github.com/the-deep/server/pull/786
## Changes
* Create ChangePasswordModal to handle password change
* Use it in MyProfile page

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations

## Note
Added FIXME comments to replace TextInput with PasswordInput when it is availabe in deep-ui