### PR TITLE
Change label of verify and control buttons

### DIFF
--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -1379,7 +1379,7 @@
         "-780818101": "Update Comment",
         "-8791231793": "last modified on",
         "-10291009": "Verify",
-        "-95647689": "Unverify",
+        "-95647689": "Verified",
         "-41523534": "Uncontrol entry",
         "-66805221": "Unverify entry",
         "-70288448": "Verified only by you",
@@ -1400,7 +1400,7 @@
         "-998103293": "Badges",
         "-797987183": "Quality Cotroller",
         "-180812081": "Control",
-        "-18084021": "Uncontrol"
+        "-18084021": "Controlled"
     },
     "links": {
         "browserExtension": {


### PR DESCRIPTION
 # Entry Review: change label of verify and control buttons

- fixes #1702

## Changes
 * If an entry is verified the button label is `Verified`
* If an entry is controlled the button label is `Controlled`

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files, or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
