### PR TITLE
Add EntriesStats component to show sources/entries statistics

### DIFF
--- a/src/components/general/EntriesStats/index.tsx
+++ b/src/components/general/EntriesStats/index.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo, useCallback } from 'react';
+import { mapToList } from '@togglecorp/fujs';
+import { EntrySummary } from '#typings';
+import {
+    ListView,
+    InformationCard,
+} from '@the-deep/deep-ui';
+import _ts from '#ts';
+
+interface Stats {
+    key: string;
+    label: string;
+    value: number;
+}
+
+type EntriesStatsKeys = Omit<EntrySummary, 'orgTypeCount' | 'countPerTocItem'>;
+
+const entriesStatsLabelMap: { [ key in (keyof EntriesStatsKeys)]: string } = {
+    totalLeads: _ts('entriesStats', 'totalLeads'),
+    totalSources: _ts('entriesStats', 'totalSources'),
+    totalUnverifiedEntries: _ts('entriesStats', 'totalUnverifiedEntries'),
+    totalVerifiedEntries: _ts('entriesStats', 'totalVerifiedEntries'),
+};
+const statsKeySelector = (d: Stats) => d.key;
+
+interface Props {
+    className?: string;
+    stats?: EntrySummary;
+}
+
+function EntriesStats(props: Props) {
+    const {
+        className,
+        stats,
+    } = props;
+
+    const statsList: Stats[] = useMemo(() =>
+        mapToList(
+            entriesStatsLabelMap,
+            (e, k) => ({
+                key: k.toString(),
+                label: e,
+                value: stats ? stats[k as keyof EntriesStatsKeys] : 0,
+            }),
+        ),
+    [stats]);
+
+    const statsRendererParams = useCallback((_: string, data: Stats) => ({
+        label: data.label,
+        value: data.value,
+        variant: 'complement1' as const, // FIXME change to matching variant when available
+        coloredBackground: true,
+    }), []);
+
+    return (
+        <ListView
+            className={className}
+            data={statsList}
+            keySelector={statsKeySelector}
+            renderer={InformationCard}
+            rendererParams={statsRendererParams}
+        />
+    );
+}
+
+export default EntriesStats;

--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -4081,6 +4081,12 @@
             "memberAddFailed": 177,
             "roleLabel": 12509,
             "editMemberLabel": -57329096
+        },
+        "entriesStats": {
+            "totalLeads": -987979879,
+            "totalSources": -987979871,
+            "totalUnverifiedEntries": -879879798,
+            "totalVerifiedEntries": -897879798
         }
     }
 }


### PR DESCRIPTION
- fixes https://github.com/the-deep/client/issues/1752
## Changes

* Add EntriesStats component to show sources/entries statistics

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
