### PR TITLE
Hot fix images in geo and organigram tagging modal

### DIFF
--- a/src/widgetComponents/Conditional/index.js
+++ b/src/widgetComponents/Conditional/index.js
@@ -16,7 +16,8 @@ const propTypes = {
     widgetType: PropTypes.string.isRequired,
     entryType: PropTypes.string,
     excerpt: PropTypes.string,
-    image: PropTypes.string,
+    imageRaw: PropTypes.string,
+    imageDetails: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     tabularField: PropTypes.number,
     tabularFieldData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     isView: PropTypes.bool,
@@ -30,7 +31,8 @@ const propTypes = {
 const defaultProps = {
     entryType: 'excerpt',
     excerpt: undefined,
-    image: undefined,
+    imageRaw: undefined,
+    imageDetails: undefined,
     tabularField: undefined,
     tabularFieldData: undefined,
     isView: false,
@@ -87,7 +89,8 @@ export default class Conditional extends React.PureComponent {
         const {
             entryType,
             excerpt,
-            image,
+            imageDetails,
+            imageRaw,
             tabularField,
             tabularFieldData,
         } = this.props;
@@ -103,7 +106,8 @@ export default class Conditional extends React.PureComponent {
                         widget={widget}
                         entryType={entryType}
                         excerpt={excerpt}
-                        image={image}
+                        imageDetails={imageDetails}
+                        imageRaw={imageRaw}
                         tabularField={tabularField}
                         tabularFieldData={tabularFieldData}
                     />

--- a/src/widgets/tagging/Geo/index.js
+++ b/src/widgets/tagging/Geo/index.js
@@ -18,7 +18,8 @@ const propTypes = {
     projectDetails: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     entryType: PropTypes.string,
     excerpt: PropTypes.string,
-    image: PropTypes.string,
+    imageRaw: PropTypes.string,
+    imageDetails: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     tabularFieldData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
@@ -27,7 +28,8 @@ const defaultProps = {
     projectDetails: {},
     entryType: undefined,
     excerpt: undefined,
-    image: undefined,
+    imageRaw: undefined,
+    imageDetails: undefined,
     tabularFieldData: undefined,
 };
 
@@ -57,8 +59,9 @@ export default class GeoWidget extends React.PureComponent {
             projectDetails,
             entryType,
             excerpt,
-            image,
             tabularFieldData,
+            imageRaw,
+            imageDetails,
         } = this.props;
 
         let excerptValue;
@@ -67,7 +70,7 @@ export default class GeoWidget extends React.PureComponent {
                 excerptValue = excerpt;
                 break;
             case IMAGE:
-                excerptValue = image;
+                excerptValue = imageDetails?.file ?? imageRaw;
                 break;
             case DATA_SERIES:
                 excerptValue = tabularFieldData;

--- a/src/widgets/tagging/Organigram/index.js
+++ b/src/widgets/tagging/Organigram/index.js
@@ -12,7 +12,8 @@ const propTypes = {
     widget: PropTypes.object.isRequired,
     entryType: PropTypes.string,
     excerpt: PropTypes.string,
-    image: PropTypes.string,
+    imageRaw: PropTypes.string,
+    imageDetails: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     tabularFieldData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
@@ -20,7 +21,8 @@ const defaultProps = {
     widget: undefined,
     entryType: undefined,
     excerpt: undefined,
-    image: undefined,
+    imageRaw: undefined,
+    imageDetails: undefined,
     tabularFieldData: undefined,
 };
 
@@ -69,8 +71,9 @@ export default class OrganigramWidget extends React.PureComponent {
         const {
             entryType,
             excerpt,
-            image,
             tabularFieldData,
+            imageRaw,
+            imageDetails,
         } = this.props;
 
         let excerptValue;
@@ -79,7 +82,7 @@ export default class OrganigramWidget extends React.PureComponent {
                 excerptValue = excerpt;
                 break;
             case IMAGE:
-                excerptValue = image;
+                excerptValue = imageDetails?.file ?? imageRaw;
                 break;
             case DATA_SERIES:
                 excerptValue = tabularFieldData;


### PR DESCRIPTION
## Changes

* Fix image entries in geo and organigram widgets

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
