### PR TITLE
Add useLocalStorage hook to use local storage for saving primary and secondary tagging information

### DIFF
--- a/src/components/general/Navbar/index.js
+++ b/src/components/general/Navbar/index.js
@@ -163,6 +163,7 @@ function Navbar(props) {
         if (confirm) {
             stopSiloTasks();
             logout();
+            localStorage.clear();
         }
         setShowLogoutConfirm(false);
     }, [logout, stopSiloTasks]);

--- a/src/components/general/Navbar/index.js
+++ b/src/components/general/Navbar/index.js
@@ -163,7 +163,8 @@ function Navbar(props) {
         if (confirm) {
             stopSiloTasks();
             logout();
-            localStorage.clear();
+            localStorage.removeItem('primaryTagging');
+            localStorage.removeItem('secondaryTagging');
         }
         setShowLogoutConfirm(false);
     }, [logout, stopSiloTasks]);

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export default function useStoredState<T>(key: string, defaultValue: T) {
+    const [value, setValue] = useState<T>((): T => {
+        const val = localStorage.getItem(key);
+        return val === null || val === undefined
+            ? defaultValue
+            : JSON.parse(val) as T;
+    });
+
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            localStorage.setItem(key, JSON.stringify(value));
+        }, 200);
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [key, value]);
+    return [value, setValue] as const;
+}

--- a/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -338,7 +338,7 @@ function PrimaryTagging(props: Props) {
         [],
     );
 
-    const [sections, setSections] = useLocalStorage<Section[]>(`${frameworkId}-primaryTagging`, initialSections);
+    const [sections, setSections] = useLocalStorage<Section[]>('primaryTagging', initialSections);
 
     const [selectedSection, setSelectedSection] = useState<string>(sections[0]?.clientId);
 

--- a/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -16,6 +16,7 @@ import { _cs, randomString } from '@togglecorp/fujs';
 import { FiEdit2 } from 'react-icons/fi';
 
 import { useModalState } from '#hooks/stateManagement';
+import useLocalStorage from '#hooks/useLocalStorage';
 import _ts from '#ts';
 
 import Canvas from '../Canvas';
@@ -337,9 +338,9 @@ function PrimaryTagging(props: Props) {
         [],
     );
 
-    const [selectedSection, setSelectedSection] = useState<string>(initialSections[0].clientId);
+    const [sections, setSections] = useLocalStorage<Section[]>(`${frameworkId}-primaryTagging`, initialSections);
 
-    const [sections, setSections] = useState<Section[]>(initialSections);
+    const [selectedSection, setSelectedSection] = useState<string>(sections[0]?.clientId);
 
     const [tempSections, setTempSections] = useState<PartialSectionType[] | undefined>();
 

--- a/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
@@ -47,7 +47,7 @@ function SecondaryTagging(props: Props) {
         setShowPreviewModalFalse,
     ] = useModalState(false);
 
-    const [widgets, setWidgets] = useLocalStorage<Widget[]>(`${frameworkId}-secondaryTagging`, []);
+    const [widgets, setWidgets] = useLocalStorage<Widget[]>('secondaryTagging', []);
 
     const [tempWidget, setTempWidget] = useState<PartialWidget | undefined>();
 

--- a/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
@@ -10,6 +10,7 @@ import {
 import { _cs } from '@togglecorp/fujs';
 
 import { useModalState } from '#hooks/stateManagement';
+import useLocalStorage from '#hooks/useLocalStorage';
 
 import _ts from '#ts';
 
@@ -46,7 +47,7 @@ function SecondaryTagging(props: Props) {
         setShowPreviewModalFalse,
     ] = useModalState(false);
 
-    const [widgets, setWidgets] = useState<Widget[]>([]);
+    const [widgets, setWidgets] = useLocalStorage<Widget[]>(`${frameworkId}-secondaryTagging`, []);
 
     const [tempWidget, setTempWidget] = useState<PartialWidget | undefined>();
 
@@ -61,7 +62,7 @@ function SecondaryTagging(props: Props) {
         (widgetId: string) => {
             setWidgets(oldWidgets => deleteWidget(oldWidgets, widgetId));
         },
-        [],
+        [setWidgets],
     );
 
     const handleWidgetEditClick = useCallback(
@@ -93,7 +94,7 @@ function SecondaryTagging(props: Props) {
             setTempWidget(undefined);
             setWidgets(oldWidgets => injectWidget(oldWidgets, value));
         },
-        [],
+        [setWidgets],
     );
 
     const appliedWidgets = useMemo(


### PR DESCRIPTION
- fixes #1803

## Changes
* add useLocalStorage hook
* use useLocalStorage hook to save primary tagging information
* use useLocalStorage hook to save secondary tagging information


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
