### PR TITLE
Add Start and End Date on Analysis Edit Modal

### DIFF
--- a/src/newViews/AnalysisModule/AnalysisEditModal/index.tsx
+++ b/src/newViews/AnalysisModule/AnalysisEditModal/index.tsx
@@ -4,6 +4,7 @@ import {
     randomString,
     isDefined,
     listToMap,
+    compareDate,
 } from '@togglecorp/fujs';
 import {
     useForm,
@@ -20,6 +21,7 @@ import {
     Modal,
     TextInput,
     SelectInput,
+    DateInput,
     List,
 } from '@the-deep/deep-ui';
 import { IoAdd } from 'react-icons/io5';
@@ -48,6 +50,8 @@ type AnalysisPillar = Partial<PillarAnalysisFields> & { key: string };
 type FormType = {
     title?: string;
     teamLead?: UserMini['id'];
+    startDate?: string;
+    endDate: string;
     analysisPillar?: AnalysisPillar[];
 }
 
@@ -80,13 +84,23 @@ const analysisFormSchema: FormSchema = {
     fields: (): FormSchemaFields => ({
         title: [requiredCondition],
         teamLead: [requiredCondition],
+        startDate: [],
+        endDate: [requiredCondition],
         analysisPillar: analysisPillarListSchema,
     }),
     validation: (value) => {
+        const errors = [];
         if ((value?.analysisPillar?.length ?? 0) < 1) {
-            return _ts('analysis.editModal', 'pillarAnalysisRequired');
+            errors.push(_ts('analysis.editModal', 'pillarAnalysisRequired'));
         }
-        return undefined;
+        if (isDefined(value?.startDate)) {
+            if ((compareDate(value?.startDate, value?.endDate) > 0)) {
+                errors.push(_ts('analysis.editModal', 'endDateGreaterThanStartDate'));
+            }
+        }
+        return errors.length > 0
+            ? errors.join(' ')
+            : undefined;
     },
 };
 
@@ -137,6 +151,8 @@ function AnalysisEditModal(props: AnalysisEditModalProps) {
             onValueSet({
                 teamLead: response.teamLead,
                 title: response.title,
+                startDate: response.startDate,
+                endDate: response.endDate,
                 analysisPillar: response.analysisPillar.map(ap => ({
                     key: String(ap.id),
                     assignee: ap.assignee,
@@ -312,6 +328,24 @@ function AnalysisEditModal(props: AnalysisEditModalProps) {
                 value={value.teamLead}
                 error={error?.fields?.teamLead}
                 onChange={onValueChange}
+                disabled={pending}
+            />
+            <DateInput
+                className={styles.input}
+                name="startDate"
+                label={_ts('analysis.editModal', 'startDateLabel')}
+                value={value.startDate}
+                onChange={onValueChange}
+                error={error?.fields?.startDate}
+                disabled={pending}
+            />
+            <DateInput
+                className={styles.input}
+                name="endDate"
+                label={_ts('analysis.editModal', 'endDateLabel')}
+                value={value.endDate}
+                onChange={onValueChange}
+                error={error?.fields?.endDate}
                 disabled={pending}
             />
             <div className={styles.analysisPillarListContainer}>

--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -1444,7 +1444,8 @@
         "-184813074847": "Assignee",
         "-1848548493": "Priority",
         "-1929391101": "Primary tagging",
-        "-1920381013": "Secondary tagging"
+        "-1920381013": "Secondary tagging",
+        "-46389656": "End date must be later than Start Date"
     },
     "links": {
         "browserExtension": {
@@ -3802,7 +3803,10 @@
             "anaylsisEditModal": -88197654,
             "editButtonLabel": 363,
             "editAnalysisModalHeading": -30091387,
-            "pillarAnalysisRequired": -91939891
+            "pillarAnalysisRequired": -91939891,
+            "endDateLabel": 334,
+            "startDateLabel": 185,
+            "endDateGreaterThanStartDate": -46389656
         },
         "pillarAnalysis": {
             "saveButtonLabel": 25,


### PR DESCRIPTION
- Addresses #1822 
- Depends on the-deep/server/pull/833

## Changes
* Add start and end date on analysis edit modal

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] translations
