### PR TITLE
Add sort behavior in primary and secondary tagging

### DIFF
--- a/src/components/ui/SortableList/index.tsx
+++ b/src/components/ui/SortableList/index.tsx
@@ -118,7 +118,7 @@ type Props<
         setNodeRef?: NodeRef;
         style?: React.CSSProperties;
     }) => JSX.Element;
-    onChange: (newList: D[], name: N) => void;
+    onChange?: (newList: D[], name: N) => void;
     direction: 'vertical' | 'horizontal' | 'rect';
     showDragOverlay?: boolean;
 }
@@ -168,7 +168,7 @@ function SortableList<
         const { active, over } = event;
         setActiveId(undefined);
 
-        if (active.id && over?.id && active.id !== over?.id && items) {
+        if (active.id && over?.id && active.id !== over?.id && items && onChange) {
             const oldIndex = items.indexOf(active.id);
             const newIndex = items.indexOf(over.id);
 

--- a/src/components/ui/SortableList/index.tsx
+++ b/src/components/ui/SortableList/index.tsx
@@ -28,6 +28,7 @@ import {
     sortableKeyboardCoordinates,
     horizontalListSortingStrategy,
     verticalListSortingStrategy,
+    rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { listToMap } from '@togglecorp/fujs';
 
@@ -118,7 +119,7 @@ type Props<
         style?: React.CSSProperties;
     }) => JSX.Element;
     onChange: (newList: D[], name: N) => void;
-    direction: 'vertical' | 'horizontal';
+    direction: 'vertical' | 'horizontal' | 'rect';
     showDragOverlay?: boolean;
 }
 
@@ -233,19 +234,36 @@ function SortableList<
         });
     }, [keySelector, rendererParams, Renderer]);
 
+    const sortingStrategy = useMemo(() => {
+        if (direction === 'rect') {
+            return rectSortingStrategy;
+        }
+        if (direction === 'vertical') {
+            return verticalListSortingStrategy;
+        }
+        return horizontalListSortingStrategy;
+    }, [direction]);
+
+    const modifiers = useMemo(() => {
+        if (direction === 'rect') {
+            return undefined;
+        }
+        return [
+            direction === 'horizontal' ? restrictToHorizontalAxis : restrictToVerticalAxis,
+        ];
+    }, [direction]);
+
     return (
         <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
-            modifiers={[
-                direction === 'horizontal' ? restrictToHorizontalAxis : restrictToVerticalAxis,
-            ]}
+            modifiers={modifiers}
         >
             <SortableContext
                 items={items}
-                strategy={direction === 'horizontal' ? horizontalListSortingStrategy : verticalListSortingStrategy}
+                strategy={sortingStrategy}
             >
                 <ListView
                     className={className}

--- a/src/newViews/AnalyticalFramework/Canvas/index.tsx
+++ b/src/newViews/AnalyticalFramework/Canvas/index.tsx
@@ -3,19 +3,117 @@ import { _cs } from '@togglecorp/fujs';
 import {
     QuickActionButton,
 } from '@the-deep/deep-ui';
+import { GrDrag } from 'react-icons/gr';
 import {
     IoCreateOutline,
     IoTrash,
 } from 'react-icons/io5';
 
+import SortableList, {
+    NodeRef,
+    Attributes,
+    Listeners,
+} from '#components/ui/SortableList';
+
 import WidgetPreview, { PartialWidget } from '../WidgetPreview';
 import styles from './styles.scss';
+
+interface WidgetProps {
+    isSecondary: boolean;
+    widget: PartialWidget;
+    clientId: string;
+    onWidgetValueChange: (value: unknown, widgetName: string) => void;
+    onWidgetEditClick: (widgetName: string) => void;
+    onWidgetDeleteClick: (widgetName: string) => void;
+    showWidgetEdit: boolean;
+    showWidgetDelete: boolean;
+    editMode: boolean;
+    setNodeRef?: NodeRef;
+    attributes?: Attributes;
+    listeners?: Listeners;
+    style?: React.CSSProperties;
+}
+
+function Widget(props: WidgetProps) {
+    const {
+        isSecondary,
+        widget,
+        clientId,
+        onWidgetValueChange,
+        onWidgetEditClick,
+        showWidgetEdit,
+        showWidgetDelete,
+        editMode,
+        onWidgetDeleteClick,
+        setNodeRef,
+        attributes,
+        listeners,
+        style,
+    } = props;
+
+    return (
+        <WidgetPreview
+            className={_cs(
+                styles.widget,
+                isSecondary && widget?.width === 'half' && styles.halfWidget,
+            )}
+            key={clientId}
+            name={clientId}
+            value={undefined}
+            onChange={onWidgetValueChange}
+            widget={widget}
+            nodeRef={setNodeRef}
+            rootStyle={style}
+            readOnly
+            actions={(
+                <>
+                    {showWidgetEdit && (
+                        <QuickActionButton
+                            name={clientId}
+                            onClick={onWidgetEditClick}
+                            // FIXME: use translation
+                            title="Edit Widget"
+                            disabled={editMode}
+                        >
+                            <IoCreateOutline />
+                        </QuickActionButton>
+                    )}
+                    {showWidgetDelete && (
+                        <QuickActionButton
+                            name={clientId}
+                            onClick={onWidgetDeleteClick}
+                            // FIXME: use translation
+                            title="Delete Widget"
+                            disabled={editMode}
+                        >
+                            <IoTrash />
+                        </QuickActionButton>
+                    )}
+                    {!editMode && (
+                        <QuickActionButton
+                            name={clientId}
+                            // FIXME: use translation
+                            title="Drag"
+                            {...attributes}
+                            {...listeners}
+                        >
+                            <GrDrag />
+                        </QuickActionButton>
+                    )}
+                </>
+            )}
+        />
+    );
+}
+
+const widgetKeySelector = (d: PartialWidget) => d.clientId;
 
 interface Props<T> {
     name: T;
     widgets: PartialWidget[] | undefined;
     onWidgetDelete?: (widgetId: string, name: T) => void;
     onWidgetEdit?: (widgetId: string, name: T) => void;
+    onWidgetOrderChange: (widgets: PartialWidget[]) => void;
     editMode?: boolean;
     isSecondary?: boolean;
 }
@@ -24,10 +122,11 @@ function Canvas<T>(props: Props<T>) {
     const {
         name,
         widgets,
-        editMode,
+        editMode = false,
         onWidgetDelete,
         onWidgetEdit,
-        isSecondary,
+        onWidgetOrderChange,
+        isSecondary = false,
     } = props;
 
     const handleWidgetValueChange = useCallback(
@@ -55,49 +154,38 @@ function Canvas<T>(props: Props<T>) {
         [onWidgetEdit, name],
     );
 
+    const widgetRendererParams = useCallback((key, data) => ({
+        clientId: key,
+        isSecondary,
+        widget: data,
+        onWidgetValueChange: handleWidgetValueChange,
+        showWidgetEdit: !!onWidgetEdit,
+        onWidgetEditClick: handleWidgetEditClick,
+        showWidgetDelete: !!onWidgetDelete,
+        onWidgetDeleteClick: handleWidgetDeleteClick,
+        editMode,
+    }), [
+        isSecondary,
+        handleWidgetValueChange,
+        handleWidgetEditClick,
+        editMode,
+        onWidgetEdit,
+        onWidgetDelete,
+        handleWidgetDeleteClick,
+    ]);
+
     return (
-        <div className={styles.canvas}>
-            {widgets?.map(widget => (
-                <WidgetPreview
-                    className={_cs(
-                        styles.widget,
-                        isSecondary && widget?.width === 'half' && styles.halfWidget,
-                    )}
-                    key={widget.clientId}
-                    name={widget.clientId}
-                    value={undefined}
-                    onChange={handleWidgetValueChange}
-                    widget={widget}
-                    readOnly
-                    actions={(
-                        <>
-                            {onWidgetEdit && (
-                                <QuickActionButton
-                                    name={widget.clientId}
-                                    onClick={handleWidgetEditClick}
-                                    // FIXME: use translation
-                                    title="Edit Widget"
-                                    disabled={editMode}
-                                >
-                                    <IoCreateOutline />
-                                </QuickActionButton>
-                            )}
-                            {onWidgetDelete && (
-                                <QuickActionButton
-                                    name={widget.clientId}
-                                    onClick={handleWidgetDeleteClick}
-                                    // FIXME: use translation
-                                    title="Delete Widget"
-                                    disabled={editMode}
-                                >
-                                    <IoTrash />
-                                </QuickActionButton>
-                            )}
-                        </>
-                    )}
-                />
-            ))}
-        </div>
+        <SortableList
+            className={styles.canvas}
+            name="widgets"
+            onChange={onWidgetOrderChange}
+            data={widgets}
+            keySelector={widgetKeySelector}
+            renderer={Widget}
+            direction="rect"
+            rendererParams={widgetRendererParams}
+            showDragOverlay
+        />
     );
 }
 export default Canvas;

--- a/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -420,7 +420,7 @@ function PrimaryTagging(props: Props) {
     );
 
     const handleWidgetOrderChange = useCallback(
-        (newWidgets: PartialWidget[]) => {
+        (newWidgets: Widget[]) => {
             const orderedWidgets = newWidgets.map((v, i) => ({ ...v, order: i }));
             setSections(oldSections => orderWidgets(oldSections, selectedSection, orderedWidgets));
         },
@@ -452,13 +452,48 @@ function PrimaryTagging(props: Props) {
         [setSections],
     );
 
-    const appliedSections = useMemo(
-        () => {
-            const mySections = [...(tempSections ?? sections)].sort(compareOrder);
-            if (tempWidget) {
-                return injectWidget(mySections, tempWidget.sectionId, tempWidget.widget);
+    type AppliedSections = {
+        editMode: false;
+        appliedSections: Section[];
+    } | {
+        editMode: true;
+        appliedSections: PartialSectionType[];
+    };
+
+    const sectionsState = useMemo(
+        (): AppliedSections => {
+            if (tempSections) {
+                const mySections = [...tempSections].sort(compareOrder);
+                if (tempWidget) {
+                    return {
+                        editMode: true,
+                        appliedSections: injectWidget(
+                            mySections,
+                            tempWidget.sectionId,
+                            tempWidget.widget,
+                        ),
+                    };
+                }
+                return {
+                    editMode: true,
+                    appliedSections: mySections,
+                };
             }
-            return mySections;
+            const mySections = [...sections].sort(compareOrder);
+            if (tempWidget) {
+                return {
+                    editMode: true,
+                    appliedSections: injectWidget(
+                        mySections,
+                        tempWidget.sectionId,
+                        tempWidget.widget,
+                    ),
+                };
+            }
+            return {
+                editMode: false,
+                appliedSections: mySections,
+            };
         },
         [sections, tempSections, tempWidget],
     );
@@ -476,8 +511,6 @@ function PrimaryTagging(props: Props) {
     const sectionEditMode = !!tempSections && !tempWidget;
     const widgetEditMode = !tempSections && !!tempWidget;
 
-    const editMode = sectionEditMode || widgetEditMode;
-
     return (
         <div className={_cs(styles.primaryTagging, className)}>
             <Container
@@ -486,7 +519,7 @@ function PrimaryTagging(props: Props) {
                 heading={_ts('analyticalFramework.primaryTagging', 'buildingModulesHeading')}
                 horizontallyCompactContent
             >
-                {!editMode && (
+                {!sectionsState.editMode && (
                     <WidgetList
                         onSectionsAdd={handleSectionsAdd}
                         onWidgetAdd={handleWidgetAdd}
@@ -540,43 +573,79 @@ function PrimaryTagging(props: Props) {
                     </div>
                     <div className={styles.canvas}>
                         <TabList className={styles.tabs}>
-                            {appliedSections.map(section => (
-                                <Tab
+                            {sectionsState.editMode
+                                ? sectionsState.appliedSections.map(section => (
+                                    <Tab
+                                        key={section.clientId}
+                                        name={section.clientId}
+                                        borderWrapperClassName={styles.borderWrapper}
+                                        className={styles.tab}
+                                        title={section.tooltip}
+                                        // FIXME: use strings
+                                    >
+                                        {section.title || 'Unnamed'}
+                                        <QuickActionButton
+                                            className={styles.sectionEditButton}
+                                            name={section.clientId}
+                                            onClick={handleSectionEditClick}
+                                            disabled
+                                        >
+                                            <FiEdit2 />
+                                        </QuickActionButton>
+                                    </Tab>
+                                ))
+                                : sectionsState.appliedSections.map(section => (
+                                    <Tab
+                                        key={section.clientId}
+                                        name={section.clientId}
+                                        borderWrapperClassName={styles.borderWrapper}
+                                        className={styles.tab}
+                                        title={section.tooltip}
+                                        // FIXME: use strings
+                                    >
+                                        {section.title}
+                                        <QuickActionButton
+                                            className={styles.sectionEditButton}
+                                            name={section.clientId}
+                                            onClick={handleSectionEditClick}
+                                        >
+                                            <FiEdit2 />
+                                        </QuickActionButton>
+                                    </Tab>
+                                ))
+                            }
+                        </TabList>
+                        {sectionsState.editMode
+                            ? sectionsState.appliedSections.map(section => (
+                                <TabPanel
                                     key={section.clientId}
                                     name={section.clientId}
-                                    borderWrapperClassName={styles.borderWrapper}
-                                    className={styles.tab}
-                                    title={section.tooltip}
-                                    // FIXME: use strings
+                                    className={styles.panel}
                                 >
-                                    {section.title || 'Unnamed'}
-                                    <QuickActionButton
-                                        className={styles.sectionEditButton}
-                                        name={section.clientId}
-                                        disabled={editMode}
-                                        onClick={handleSectionEditClick}
-                                    >
-                                        <FiEdit2 />
-                                    </QuickActionButton>
-                                </Tab>
-                            ))}
-                        </TabList>
-                        {appliedSections.map(section => (
-                            <TabPanel
-                                key={section.clientId}
-                                name={section.clientId}
-                                className={styles.panel}
-                            >
-                                <Canvas
-                                    name={selectedSection}
-                                    widgets={section.widgets}
-                                    onWidgetDelete={handleWidgetDeleteClick}
-                                    onWidgetEdit={handleWidgetEditClick}
-                                    onWidgetOrderChange={handleWidgetOrderChange}
-                                    editMode={editMode}
-                                />
-                            </TabPanel>
-                        ))}
+                                    <Canvas
+                                        name={selectedSection}
+                                        widgets={section.widgets}
+                                        editMode
+                                    />
+                                </TabPanel>
+                            ))
+                            : sectionsState.appliedSections.map(section => (
+                                <TabPanel
+                                    key={section.clientId}
+                                    name={section.clientId}
+                                    className={styles.panel}
+                                >
+                                    <Canvas
+                                        name={selectedSection}
+                                        widgets={section.widgets}
+                                        onWidgetDelete={handleWidgetDeleteClick}
+                                        onWidgetEdit={handleWidgetEditClick}
+                                        onWidgetOrderChange={handleWidgetOrderChange}
+                                        editMode={false}
+                                    />
+                                </TabPanel>
+                            ))
+                        }
                     </div>
                 </Tabs>
             </div>

--- a/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -31,6 +31,7 @@ import {
     TempWidget,
     findWidget,
     injectWidget,
+    orderWidgets,
     deleteWidget,
 } from './utils';
 
@@ -418,6 +419,14 @@ function PrimaryTagging(props: Props) {
         [sections],
     );
 
+    const handleWidgetOrderChange = useCallback(
+        (newWidgets: PartialWidget[]) => {
+            const orderedWidgets = newWidgets.map((v, i) => ({ ...v, order: i }));
+            setSections(oldSections => orderWidgets(oldSections, selectedSection, orderedWidgets));
+        },
+        [selectedSection, setSections],
+    );
+
     const handleWidgetEditCancel = useCallback(
         () => {
             setTempWidget(undefined);
@@ -563,6 +572,7 @@ function PrimaryTagging(props: Props) {
                                     widgets={section.widgets}
                                     onWidgetDelete={handleWidgetDeleteClick}
                                     onWidgetEdit={handleWidgetEditClick}
+                                    onWidgetOrderChange={handleWidgetOrderChange}
                                     editMode={editMode}
                                 />
                             </TabPanel>

--- a/src/newViews/AnalyticalFramework/PrimaryTagging/utils.ts
+++ b/src/newViews/AnalyticalFramework/PrimaryTagging/utils.ts
@@ -27,6 +27,23 @@ export function findWidget(
     );
 }
 
+export function orderWidgets(
+    sections: Section[],
+    sectionId: string,
+    widgets: Widget[],
+): Section[] {
+    const selectedSectionIndex = sections.findIndex(s => s.clientId === sectionId);
+    if (selectedSectionIndex === -1) {
+        console.error('The selected section does not exist:', sectionId);
+        return sections;
+    }
+
+    return produce(sections, (safeSections) => {
+        const selectedSection = safeSections[selectedSectionIndex];
+        selectedSection.widgets = widgets;
+    });
+}
+
 export function injectWidget(
     sections: Section[],
     sectionId: string,

--- a/src/newViews/AnalyticalFramework/Review/index.tsx
+++ b/src/newViews/AnalyticalFramework/Review/index.tsx
@@ -64,6 +64,7 @@ function Review(props: Props) {
                                 <Canvas
                                     name={selectedSection}
                                     widgets={section.widgets}
+                                    editMode={false}
                                 />
                             </TabPanel>
                         ))}
@@ -77,6 +78,7 @@ function Review(props: Props) {
                 <Canvas
                     name={undefined}
                     widgets={widgets}
+                    editMode={false}
                 />
             </ContainerCard>
         </div>

--- a/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
@@ -76,7 +76,7 @@ function SecondaryTagging(props: Props) {
     );
 
     const handleWidgetOrderChange = useCallback(
-        (newWidgets: PartialWidget[]) => {
+        (newWidgets: Widget[]) => {
             const orderedWidgets = newWidgets.map((v, i) => ({ ...v, order: i }));
             setWidgets(orderedWidgets);
         },
@@ -105,17 +105,29 @@ function SecondaryTagging(props: Props) {
         [setWidgets],
     );
 
-    const appliedWidgets = useMemo(
+    type AppliedWidgets = {
+        editMode: false;
+        appliedWidgets: Widget[];
+    } | {
+        editMode: true;
+        appliedWidgets: PartialWidget[];
+    };
+
+    const widgetsState: AppliedWidgets = useMemo(
         () => {
             if (tempWidget) {
-                return injectWidget(widgets, tempWidget);
+                return {
+                    editMode: true,
+                    appliedWidgets: injectWidget(widgets, tempWidget),
+                };
             }
-            return widgets;
+            return {
+                editMode: false,
+                appliedWidgets: widgets,
+            };
         },
         [tempWidget, widgets],
     );
-
-    const editMode = !!tempWidget;
 
     return (
         <div className={_cs(styles.secondaryTagging, className)}>
@@ -125,13 +137,13 @@ function SecondaryTagging(props: Props) {
                 contentClassName={styles.content}
                 horizontallyCompactContent
             >
-                {!editMode && (
+                {!widgetsState.editMode && (
                     <WidgetList
                         sectionsDisabled
                         onWidgetAdd={handleWidgetAdd}
                     />
                 )}
-                {editMode && tempWidget && (
+                {widgetsState.editMode && tempWidget && (
                     <WidgetEditor
                         name={undefined}
                         initialValue={tempWidget}
@@ -163,15 +175,24 @@ function SecondaryTagging(props: Props) {
                     </ElementFragments>
                 </div>
                 <div className={styles.canvas}>
-                    <Canvas
-                        name={undefined}
-                        widgets={appliedWidgets}
-                        onWidgetDelete={handleWidgetDeleteClick}
-                        onWidgetEdit={handleWidgetEditClick}
-                        onWidgetOrderChange={handleWidgetOrderChange}
-                        editMode={editMode}
-                        isSecondary
-                    />
+                    {widgetsState.editMode ? (
+                        <Canvas
+                            name={undefined}
+                            widgets={widgetsState.appliedWidgets}
+                            editMode
+                            isSecondary
+                        />
+                    ) : (
+                        <Canvas
+                            name={undefined}
+                            widgets={widgetsState.appliedWidgets}
+                            onWidgetDelete={handleWidgetDeleteClick}
+                            onWidgetEdit={handleWidgetEditClick}
+                            onWidgetOrderChange={handleWidgetOrderChange}
+                            editMode={false}
+                            isSecondary
+                        />
+                    )}
                 </div>
             </div>
             {showPreviewModal && (

--- a/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
+++ b/src/newViews/AnalyticalFramework/SecondaryTagging/index.tsx
@@ -75,6 +75,14 @@ function SecondaryTagging(props: Props) {
         [widgets],
     );
 
+    const handleWidgetOrderChange = useCallback(
+        (newWidgets: PartialWidget[]) => {
+            const orderedWidgets = newWidgets.map((v, i) => ({ ...v, order: i }));
+            setWidgets(orderedWidgets);
+        },
+        [setWidgets],
+    );
+
     const handleWidgetEditCancel = useCallback(
         () => {
             setTempWidget(undefined);
@@ -160,6 +168,7 @@ function SecondaryTagging(props: Props) {
                         widgets={appliedWidgets}
                         onWidgetDelete={handleWidgetDeleteClick}
                         onWidgetEdit={handleWidgetEditClick}
+                        onWidgetOrderChange={handleWidgetOrderChange}
                         editMode={editMode}
                         isSecondary
                     />

--- a/src/newViews/AnalyticalFramework/Widget/index.tsx
+++ b/src/newViews/AnalyticalFramework/Widget/index.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { _cs } from '@togglecorp/fujs';
 import { Header } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import styles from './styles.scss';
 
 export interface Props {
     title: string | undefined;
     className?: string;
     headerClassName?: string;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 
     actions?: React.ReactNode,
     actionsContainerClassName?: string;
@@ -28,10 +33,16 @@ function WidgetWrapper(props: Props) {
         headerClassName,
         actionsContainerClassName,
         childrenContainerClassName,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
-        <div className={_cs(className, styles.widget)}>
+        <div
+            className={_cs(className, styles.widget)}
+            style={rootStyle}
+            ref={nodeRef}
+        >
             <Header
                 // FIXME: use strings
                 heading={title ?? 'Unnamed'}

--- a/src/newViews/AnalyticalFramework/Widget/styles.scss
+++ b/src/newViews/AnalyticalFramework/Widget/styles.scss
@@ -1,6 +1,7 @@
 .widget {
     display: flex;
     flex-direction: column;
+    background-color: var(--dui-color-foreground);
     overflow-y: auto;
 
     .header {

--- a/src/newViews/AnalyticalFramework/WidgetPreview/BaseWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/BaseWidgetInput/index.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { Card } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 
 export interface Props{
     title: string | undefined;
     className?: string;
     actions?: React.ReactNode,
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function BaseWidgetInput(props: Props) {
@@ -14,6 +19,8 @@ function BaseWidgetInput(props: Props) {
         className,
         title,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -21,6 +28,8 @@ function BaseWidgetInput(props: Props) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <Card>
                 {/* FIXME: use strings */}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/DateRangeWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/DateRangeWidgetInput/index.tsx
@@ -5,6 +5,8 @@ import {
 } from '@the-deep/deep-ui';
 import { IoSwapHorizontal } from 'react-icons/io5';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 import { DateRangeValue } from '../../types';
 
@@ -21,6 +23,9 @@ export interface Props <N extends string>{
     actions?: React.ReactNode,
     disabled?: boolean;
     readOnly?: boolean;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function DateRangeWidgetInput<N extends string>(props: Props<N>) {
@@ -33,6 +38,8 @@ function DateRangeWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     const handleToChange = useCallback(
@@ -61,6 +68,8 @@ function DateRangeWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <DateInput
                 name="from"

--- a/src/newViews/AnalyticalFramework/WidgetPreview/DateWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/DateWidgetInput/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { DateInput } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 import { DateValue } from '../../types';
 
@@ -15,6 +17,9 @@ export interface Props <N extends string>{
     actions?: React.ReactNode,
     disabled?: boolean;
     readOnly?: boolean;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function DateWidgetInput<N extends string>(props: Props<N>) {
@@ -27,6 +32,8 @@ function DateWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -34,6 +41,8 @@ function DateWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <DateInput
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/Matrix1dWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/Matrix1dWidgetInput/index.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react';
 import { Button, List } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import { Matrix1dValue, Matrix1dWidget, PartialForm } from '../../types';
 import WidgetWrapper from '../../Widget';
 
@@ -133,6 +135,8 @@ export interface Props <N extends string>{
     readOnly?: boolean;
 
     widget: PartialMatrix1dWidget,
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function Matrix1dWidgetInput<N extends string>(props: Props<N>) {
@@ -146,6 +150,8 @@ function Matrix1dWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     const handleCellChange = useCallback(
@@ -183,6 +189,8 @@ function Matrix1dWidgetInput<N extends string>(props: Props<N>) {
             childrenContainerClassName={styles.matrix1d}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <List
                 data={widget?.data?.rows}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/Matrix2dWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/Matrix2dWidgetInput/index.tsx
@@ -6,6 +6,8 @@ import {
     List,
 } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import { Matrix2dValue, Matrix2dWidget, PartialForm } from '../../types';
 import WidgetWrapper from '../../Widget';
 
@@ -227,6 +229,8 @@ export interface Props <N extends string>{
     readOnly?: boolean;
 
     widget: PartialMatrix2dWidget,
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function Matrix2dWidgetInput<N extends string>(props: Props<N>) {
@@ -240,6 +244,8 @@ function Matrix2dWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     const handleSubRowChange = useCallback(
@@ -283,6 +289,8 @@ function Matrix2dWidgetInput<N extends string>(props: Props<N>) {
             childrenContainerClassName={styles.matrix2d}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <List
                 data={widget?.data?.rows}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/MultiSelectWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/MultiSelectWidgetInput/index.tsx
@@ -3,6 +3,8 @@ import {
     MultiSelectInput,
 } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import { MultiSelectValue, MultiSelectWidget, PartialForm } from '../../types';
 import WidgetWrapper from '../../Widget';
 
@@ -31,6 +33,9 @@ export interface Props <N extends string>{
     readOnly?: boolean;
 
     widget: PartialMultiSelectWidget,
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function MultiSelectWidgetInput<N extends string>(props: Props<N>) {
@@ -44,6 +49,8 @@ function MultiSelectWidgetInput<N extends string>(props: Props<N>) {
         widget,
         disabled,
         readOnly,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -51,6 +58,8 @@ function MultiSelectWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <MultiSelectInput
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/NumberWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/NumberWidgetInput/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NumberInput } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 import { NumberValue } from '../../types';
 
@@ -15,6 +17,9 @@ export interface Props <N extends string>{
     actions?: React.ReactNode,
     disabled?: boolean;
     readOnly?: boolean;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function NumberWidgetInput<N extends string>(props: Props<N>) {
@@ -27,6 +32,8 @@ function NumberWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -34,6 +41,8 @@ function NumberWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <NumberInput
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/ScaleWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/ScaleWidgetInput/index.tsx
@@ -3,6 +3,8 @@ import {
     ScaleInput,
 } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import { ScaleValue, ScaleWidget, PartialForm } from '../../types';
 import WidgetWrapper from '../../Widget';
 
@@ -32,6 +34,9 @@ export interface Props<N extends string>{
     readOnly?: boolean;
 
     widget: PartialScaleWidget,
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function ScaleWidgetInput<N extends string>(props: Props<N>) {
@@ -45,6 +50,8 @@ function ScaleWidgetInput<N extends string>(props: Props<N>) {
         widget,
         disabled,
         readOnly,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -52,6 +59,8 @@ function ScaleWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <ScaleInput
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/SingleSelectWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/SingleSelectWidgetInput/index.tsx
@@ -3,6 +3,8 @@ import {
     SelectInput,
 } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import { SingleSelectValue, SingleSelectWidget, PartialForm } from '../../types';
 import WidgetWrapper from '../../Widget';
 
@@ -31,6 +33,9 @@ export interface Props <N extends string>{
     readOnly?: boolean;
 
     widget: PartialSingleSelectWidget,
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function SingleSelectWidgetInput<N extends string>(props: Props<N>) {
@@ -44,6 +49,8 @@ function SingleSelectWidgetInput<N extends string>(props: Props<N>) {
         widget,
         disabled,
         readOnly,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -51,6 +58,8 @@ function SingleSelectWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <SelectInput
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/TextWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/TextWidgetInput/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { TextArea } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 import { TextValue } from '../../types';
 
@@ -15,6 +17,9 @@ export interface Props <N extends string>{
     actions?: React.ReactNode,
     disabled?: boolean;
     readOnly?: boolean;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function TextWidgetInput<N extends string>(props: Props<N>) {
@@ -27,6 +32,8 @@ function TextWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -34,6 +41,8 @@ function TextWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <TextArea
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/TimeRangeWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/TimeRangeWidgetInput/index.tsx
@@ -5,6 +5,8 @@ import {
 } from '@the-deep/deep-ui';
 import { IoSwapHorizontal } from 'react-icons/io5';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 import { TimeRangeValue } from '../../types';
 
@@ -21,6 +23,9 @@ export interface Props <N extends string>{
     actions?: React.ReactNode,
     disabled?: boolean;
     readOnly?: boolean;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function TimeRangeWidgetInput<N extends string>(props: Props<N>) {
@@ -33,6 +38,8 @@ function TimeRangeWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     const handleToChange = useCallback(
@@ -61,6 +68,8 @@ function TimeRangeWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <TextInput // TODO use TimeRangeInput when added to deep-ui
                 name="from"

--- a/src/newViews/AnalyticalFramework/WidgetPreview/TimeWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/TimeWidgetInput/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { TextInput } from '@the-deep/deep-ui';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import WidgetWrapper from '../../Widget';
 import { TimeValue } from '../../types';
 
@@ -15,6 +17,9 @@ export interface Props <N extends string>{
     actions?: React.ReactNode,
     disabled?: boolean;
     readOnly?: boolean;
+
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
 
 function TimeWidgetInput<N extends string>(props: Props<N>) {
@@ -27,6 +32,8 @@ function TimeWidgetInput<N extends string>(props: Props<N>) {
         disabled,
         readOnly,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     return (
@@ -34,6 +41,8 @@ function TimeWidgetInput<N extends string>(props: Props<N>) {
             className={className}
             title={title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         >
             <TextInput // TODO: use TimeInput component when it is added
                 name={name}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { NodeRef } from '#components/ui/SortableList';
+
 import { Widget, PartialForm } from '../types';
 import TextWidgetInput, { Props as TextWidgetInputProps } from './TextWidgetInput';
 import DateWidgetInput, { Props as DateWidgetInputProps } from './DateWidgetInput';
@@ -29,7 +31,10 @@ interface Props <N extends string, T>{
     actions?: React.ReactNode,
     readOnly?: boolean;
     disabled?: boolean;
+    nodeRef?: NodeRef;
+    rootStyle?: React.CSSProperties;
 }
+
 function WidgetPreview<N extends string, T>(props: Props<N, T>) {
     const {
         className,
@@ -40,6 +45,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
         readOnly,
         disabled,
         actions,
+        nodeRef,
+        rootStyle,
     } = props;
 
     if (widget.type === 'text') {
@@ -57,6 +64,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 readOnly={readOnly}
                 disabled={disabled}
                 actions={actions}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -75,6 +84,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 readOnly={readOnly}
                 disabled={disabled}
                 actions={actions}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -93,6 +104,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 readOnly={readOnly}
                 disabled={disabled}
                 actions={actions}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -111,6 +124,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 readOnly={readOnly}
                 disabled={disabled}
                 actions={actions}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -129,6 +144,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 readOnly={readOnly}
                 disabled={disabled}
                 actions={actions}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -146,6 +163,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 readOnly={readOnly}
                 disabled={disabled}
                 actions={actions}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -165,6 +184,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 disabled={disabled}
                 actions={actions}
                 widget={widget}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -184,6 +205,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 disabled={disabled}
                 actions={actions}
                 widget={widget}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -202,6 +225,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 disabled={disabled}
                 actions={actions}
                 widget={widget}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -221,6 +246,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 disabled={disabled}
                 actions={actions}
                 widget={widget}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -240,6 +267,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
                 disabled={disabled}
                 actions={actions}
                 widget={widget}
+                nodeRef={nodeRef}
+                rootStyle={rootStyle}
             />
         );
     }
@@ -248,6 +277,8 @@ function WidgetPreview<N extends string, T>(props: Props<N, T>) {
             className={className}
             title={widget.title}
             actions={actions}
+            nodeRef={nodeRef}
+            rootStyle={rootStyle}
         />
     );
 }


### PR DESCRIPTION
- Addresses https://github.com/the-deep/client/issues/1804, https://github.com/the-deep/client/issues/1827

## Changes

* Add ordering of widgets in primary and secondary tagging

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [ ] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
