### PR TITLE
Add GeoAreas tab to Project page

### DIFF
--- a/src/newViews/ProjectEdit/GeoAreas/RegionCard/AdminLevelCard/index.tsx
+++ b/src/newViews/ProjectEdit/GeoAreas/RegionCard/AdminLevelCard/index.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { _cs } from '@togglecorp/fujs';
+
+import { AdminLevel } from '#typings';
+import {
+    TextInput,
+    Container,
+} from '@the-deep/deep-ui';
+import _ts from '#ts';
+
+import styles from './styles.scss';
+
+interface Props {
+    className?: string;
+    adminLevel: AdminLevel;
+}
+
+function AdminLevelCard(props: Props) {
+    const {
+        className,
+        adminLevel,
+    } = props;
+
+    return (
+        <Container
+            className={_cs(className, styles.adminLevel)}
+            sub
+            headingClassName={styles.title}
+            heading={adminLevel.title}
+            contentClassName={styles.content}
+        >
+            <div className={styles.row}>
+                <TextInput
+                    label={_ts('geoAreas', 'adminLevel')}
+                    name="level"
+                    readOnly
+                    value={adminLevel.level.toString()}
+                />
+                <TextInput
+                    label={_ts('geoAreas', 'adminLevelName')}
+                    name="name"
+                    readOnly
+                    value={adminLevel.title}
+                />
+            </div>
+            <div className={styles.row}>
+                <TextInput
+                    label={_ts('geoAreas', 'idProperty')}
+                    name="codeProp"
+                    readOnly
+                    value={adminLevel.codeProp}
+                />
+                <TextInput
+                    label={_ts('geoAreas', 'propertyName')}
+                    name="nameProp"
+                    readOnly
+                    value={adminLevel.nameProp}
+                />
+            </div>
+            <div className={styles.row}>
+                <TextInput
+                    label={_ts('geoAreas', 'idParent')}
+                    name="parentCodeProps"
+                    readOnly
+                    value={adminLevel.parentCodeProp}
+                />
+                <TextInput
+                    label={_ts('geoAreas', 'parentName')}
+                    name="parentNameProp"
+                    readOnly
+                    value={adminLevel.parentNameProp}
+                />
+            </div>
+        </Container>
+    );
+}
+
+export default AdminLevelCard;

--- a/src/newViews/ProjectEdit/GeoAreas/RegionCard/AdminLevelCard/styles.scss
+++ b/src/newViews/ProjectEdit/GeoAreas/RegionCard/AdminLevelCard/styles.scss
@@ -1,24 +1,23 @@
-.region {
+.admin-level {
     display: flex;
-    flex-direction: column;
     flex-grow: 1;
 
-    .header {
-        background-color: var(--dui-color-background);
+    .title {
         padding: var(--dui-spacing-small);
+        color: var(--dui-color-accent);
         font-size: var(--dui-font-size-large);
         font-weight: var(--dui-font-weight-bold);
     }
 
-    .admin-levels {
+    .content {
         display: flex;
         flex-direction: column;
         flex-grow: 1;
 
-        .admin-level {
+        .row {
             display: flex;
             flex-grow: 1;
-            padding: 0 var(--dui-spacing-small);
+            justify-content: space-between;
         }
     }
 }

--- a/src/newViews/ProjectEdit/GeoAreas/RegionCard/index.tsx
+++ b/src/newViews/ProjectEdit/GeoAreas/RegionCard/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { _cs } from '@togglecorp/fujs';
+import { IoTrash } from 'react-icons/io5';
+import {
+    QuickActionConfirmButton,
+    ElementFragments,
+} from '@the-deep/deep-ui';
+
+import _ts from '#ts';
+import { BasicRegion } from '#typings';
+
+import styles from './styles.scss';
+
+interface Props {
+    region: BasicRegion;
+    className?: string;
+}
+
+function RegionCard(props: Props) {
+    const {
+        className,
+        region,
+    } = props;
+
+    const handleDeleteRegionClick = () => {}; // FIXME  this will be added later
+
+    return (
+        <div className={_cs(className, styles.region)}>
+            <ElementFragments
+                childrenContainerClassName={styles.title}
+                actionsContainerClassName={styles.button}
+                actions={(
+                    <QuickActionConfirmButton
+                        name="deleteButton"
+                        title={_ts('geoAreas', 'deleteGeoArea')}
+                        onConfirm={handleDeleteRegionClick}
+                        message={_ts('geoAreas', 'deleteGeoAreaConfirm')}
+                        showConfirmationInitially={false}
+                    >
+                        <IoTrash />
+                    </QuickActionConfirmButton>
+                )}
+            >
+                {region.title}
+            </ElementFragments>
+        </div>
+    );
+}
+
+export default RegionCard;

--- a/src/newViews/ProjectEdit/GeoAreas/RegionCard/index.tsx
+++ b/src/newViews/ProjectEdit/GeoAreas/RegionCard/index.tsx
@@ -1,15 +1,26 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { _cs } from '@togglecorp/fujs';
-import { IoTrash } from 'react-icons/io5';
 import {
+    IoTrash,
+} from 'react-icons/io5';
+import {
+    ListView,
+    ExpandableContainer,
     QuickActionConfirmButton,
-    ElementFragments,
 } from '@the-deep/deep-ui';
+import { useRequest } from '#utils/request';
 
 import _ts from '#ts';
-import { BasicRegion } from '#typings';
+import {
+    AdminLevel,
+    BasicRegion,
+    Region,
+} from '#typings';
 
+import AdminLevelCard from './AdminLevelCard';
 import styles from './styles.scss';
+
+const adminLevelKeySelector = (d: AdminLevel) => d.id;
 
 interface Props {
     region: BasicRegion;
@@ -22,28 +33,48 @@ function RegionCard(props: Props) {
         region,
     } = props;
 
+    const {
+        response,
+    } = useRequest<Region>({
+        url: `server://regions/${region.id}/`,
+        method: 'GET',
+        failureHeader: _ts('geoAreas', 'title'),
+    });
     const handleDeleteRegionClick = () => {}; // FIXME  this will be added later
 
+    const adminLevelRendererParams = useCallback((_: number, data: AdminLevel) => ({
+        adminLevel: data,
+    }), []);
+
     return (
-        <div className={_cs(className, styles.region)}>
-            <ElementFragments
-                childrenContainerClassName={styles.title}
-                actionsContainerClassName={styles.button}
-                actions={(
-                    <QuickActionConfirmButton
-                        name="deleteButton"
-                        title={_ts('geoAreas', 'deleteGeoArea')}
-                        onConfirm={handleDeleteRegionClick}
-                        message={_ts('geoAreas', 'deleteGeoAreaConfirm')}
-                        showConfirmationInitially={false}
-                    >
-                        <IoTrash />
-                    </QuickActionConfirmButton>
-                )}
-            >
-                {region.title}
-            </ElementFragments>
-        </div>
+        <ExpandableContainer
+            className={_cs(className, styles.region)}
+            headerClassName={styles.header}
+            heading={region.title}
+            sub
+            headerActions={(
+                <QuickActionConfirmButton
+                    name="deleteButton"
+                    title={_ts('geoAreas', 'deleteGeoArea')}
+                    onConfirm={handleDeleteRegionClick}
+                    message={_ts('geoAreas', 'deleteGeoAreaConfirm')}
+                    showConfirmationInitially={false}
+                >
+                    <IoTrash />
+                </QuickActionConfirmButton>
+            )}
+        >
+            {(response && !response.public && response.adminLevels.length > 0) && (
+                <ListView
+                    className={styles.adminLevels}
+                    data={response?.adminLevels}
+                    rendererParams={adminLevelRendererParams}
+                    renderer={AdminLevelCard}
+                    rendererClassName={styles.adminLevel}
+                    keySelector={adminLevelKeySelector}
+                />
+            )}
+        </ExpandableContainer>
     );
 }
 

--- a/src/newViews/ProjectEdit/GeoAreas/RegionCard/styles.scss
+++ b/src/newViews/ProjectEdit/GeoAreas/RegionCard/styles.scss
@@ -1,0 +1,15 @@
+.region {
+    display: flex;
+    background-color: var(--dui-color-background);
+    padding: var(--dui-spacing-small);
+
+    .button {
+        margin-left: auto;
+    }
+
+    .title {
+        padding: var(--dui-spacing-small);
+        font-size: var(--dui-font-weight-large);
+        font-weight: var(--dui-font-weight-bold);
+    }
+}

--- a/src/newViews/ProjectEdit/GeoAreas/index.tsx
+++ b/src/newViews/ProjectEdit/GeoAreas/index.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback } from 'react';
+import { _cs } from '@togglecorp/fujs';
+import {
+    Button,
+    ListView,
+    ExpandableContainer,
+} from '@the-deep/deep-ui';
+import {
+    IoAdd,
+} from 'react-icons/io5';
+
+import {
+    BasicRegion,
+} from '#typings';
+import _ts from '#ts';
+
+import RegionCard from './RegionCard';
+import styles from './styles.scss';
+
+const regionKeySelector = (d: BasicRegion): number => d.id;
+
+interface Props {
+    className?: string;
+    regions: BasicRegion[];
+}
+
+function GeoAreas(props: Props) {
+    const {
+        className,
+        regions,
+    } = props;
+
+    const regionRendererParams = useCallback((_: number, data: BasicRegion) => ({
+        region: data,
+    }), []);
+
+    return (
+        <div className={_cs(className, styles.geoAreas)}>
+            <div className={styles.mapContainer}>
+                map
+            </div>
+            <div className={styles.listContainer}>
+                <Button
+                    className={styles.addCustom}
+                    variant="secondary"
+                    name="addCustomGeo"
+                    icons={<IoAdd />}
+                >
+                    {_ts('geoAreas', 'addCustom')}
+                </Button>
+                <ExpandableContainer
+                    className={styles.geoAreasDropdown}
+                    sub
+                    defaultVisibility
+                    heading={_ts('geoAreas', 'title')}
+                >
+                    <ListView
+                        className={styles.regions}
+                        data={regions}
+                        rendererParams={regionRendererParams}
+                        renderer={RegionCard}
+                        rendererClassName={styles.region}
+                        keySelector={regionKeySelector}
+                    />
+                </ExpandableContainer>
+            </div>
+        </div>
+    );
+}
+
+export default GeoAreas;

--- a/src/newViews/ProjectEdit/GeoAreas/index.tsx
+++ b/src/newViews/ProjectEdit/GeoAreas/index.tsx
@@ -17,7 +17,7 @@ import _ts from '#ts';
 import RegionCard from './RegionCard';
 import styles from './styles.scss';
 
-const regionKeySelector = (d: BasicRegion): number => d.id;
+const regionKeySelector = (d: BasicRegion) => d.id;
 
 interface Props {
     className?: string;
@@ -50,6 +50,8 @@ function GeoAreas(props: Props) {
                 </Button>
                 <ExpandableContainer
                     className={styles.geoAreasDropdown}
+                    headerClassName={styles.header}
+                    contentClassName={styles.content}
                     sub
                     defaultVisibility
                     heading={_ts('geoAreas', 'title')}

--- a/src/newViews/ProjectEdit/GeoAreas/styles.scss
+++ b/src/newViews/ProjectEdit/GeoAreas/styles.scss
@@ -17,32 +17,40 @@
         flex-grow: 1;
         padding: var(--dui-spacing-medium);
 
-
         .add-custom {
+            display: flex;
+            flex-shrink: 0;
             margin-left: auto;
         }
 
         .geo-areas-dropdown {
             display: flex;
             margin: var(--dui-spacing-medium) 0 var(--dui-spacing-small) 0;
-            border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-grey4);
-            background-color: var(--dui-color-white);
             padding: var(--dui-spacing-medium);
-            font-size: var(--dui-font-size-large);
             font-weight: var(--dui-font-weight-bold);
 
-            .button {
-                margin-left: auto;
+            .header {
+                border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-grey4);
             }
-        }
 
-        .regions {
-            display: flex;
-            flex-direction: column;
-            flex-grow: 1;
-
-            .region {
+            .content {
                 display: flex;
+                flex-grow: 1;
+
+                .regions {
+                    display: flex;
+                    flex-direction: column;
+                    flex-grow: 1;
+                    overflow-y: auto;
+
+                    .region {
+                        display: flex;
+                        flex-grow: 1;
+                        flex-shrink: 0;
+                        margin-bottom: var(--dui-spacing-small);
+                        background-color: var(--dui-color-background);
+                    }
+                }
             }
         }
     }

--- a/src/newViews/ProjectEdit/GeoAreas/styles.scss
+++ b/src/newViews/ProjectEdit/GeoAreas/styles.scss
@@ -1,0 +1,49 @@
+.geo-areas {
+    display: flex;
+    flex-grow: 1;
+    margin: var(--dui-spacing-large) var(--dui-spacing-extra-large);
+    background-color: var(--dui-color-white);
+
+    .map-container {
+        display: flex;
+        flex-basis: 60%;
+        flex-grow: 1;
+    }
+
+    .list-container {
+        display: flex;
+        flex-basis: 40%;
+        flex-direction: column;
+        flex-grow: 1;
+        padding: var(--dui-spacing-medium);
+
+
+        .add-custom {
+            margin-left: auto;
+        }
+
+        .geo-areas-dropdown {
+            display: flex;
+            margin: var(--dui-spacing-medium) 0 var(--dui-spacing-small) 0;
+            border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-grey4);
+            background-color: var(--dui-color-white);
+            padding: var(--dui-spacing-medium);
+            font-size: var(--dui-font-size-large);
+            font-weight: var(--dui-font-weight-bold);
+
+            .button {
+                margin-left: auto;
+            }
+        }
+
+        .regions {
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+
+            .region {
+                display: flex;
+            }
+        }
+    }
+}

--- a/src/newViews/ProjectEdit/index.tsx
+++ b/src/newViews/ProjectEdit/index.tsx
@@ -32,6 +32,7 @@ import {
 import ProjectDetailsForm from './ProjectDetailsForm';
 import Framework from './Framework';
 import Users from './Users';
+import GeoAreas from './GeoAreas';
 import styles from './styles.scss';
 
 interface PropsFromDispatch {
@@ -116,6 +117,13 @@ function ProjectEdit(props: PropsFromState & PropsFromDispatch) {
                             {_ts('projectEdit', 'projectDetailsLabel')}
                         </Tab>
                         <Tab
+                            name="geo-areas"
+                            className={styles.tab}
+                            disabled={isNotDefined(projectId)}
+                        >
+                            {_ts('projectEdit', 'geoAreas')}
+                        </Tab>
+                        <Tab
                             name="users"
                             className={styles.tab}
                             disabled={isNotDefined(projectId)}
@@ -140,6 +148,14 @@ function ProjectEdit(props: PropsFromState & PropsFromDispatch) {
                             key={projectId}
                             projectId={projectId}
                             onCreate={handleCreate}
+                        />
+                    </TabPanel>
+                    <TabPanel
+                        className={styles.tabPanel}
+                        name="geo-areas"
+                    >
+                        <GeoAreas
+                            regions={activeProject.regions}
                         />
                     </TabPanel>
                     <TabPanel

--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -1449,7 +1449,11 @@
         "-1393010101": "Deep image input",
         "-11018101832": "Uploading a file",
         "-183103101891": "No file selected",
-        "-1941381010101": "?"
+        "-1941381010101": "?",
+        "-192931013": "Geo Areas",
+        "-1381310011": "Add a custom geo area",
+        "-1181081010": "Delete geo area",
+        "-1828391488": "Do you really want to remove this geo area from the project?"
     },
     "links": {
         "browserExtension": {
@@ -3950,7 +3954,8 @@
             "searchPlaceholder": 14,
             "noFrameworks": -20004833,
             "removeUserConfirmation": -13184074,
-            "removeUserGroupConfirmation": -1778933
+            "removeUserGroupConfirmation": -1778933,
+            "geoAreas": -192931013
         },
         "components.dateRangeOutput": {
             "endDateLabel": 334,
@@ -4193,6 +4198,12 @@
             "uploading": -11018101832,
             "noFiles": -183103101891,
             "questionMark": -1941381010101
+        },
+        "geoAreas": {
+            "title": -192931013,
+            "addCustom": -1381310011,
+            "deleteGeoArea": -1181081010,
+            "deleteGeoAreaConfirm": -1828391488
         }
     }
 }

--- a/src/redux/initial-state/dev-lang.json
+++ b/src/redux/initial-state/dev-lang.json
@@ -1453,7 +1453,13 @@
         "-192931013": "Geo Areas",
         "-1381310011": "Add a custom geo area",
         "-1181081010": "Delete geo area",
-        "-1828391488": "Do you really want to remove this geo area from the project?"
+        "-1828391488": "Do you really want to remove this geo area from the project?",
+        "-1924381012": "Admin Level",
+        "-1818401301": "Admin Level Name",
+        "-1383841901": "ID property",
+        "-14834810210": "Property Name",
+        "-1948348191": "ID Parent",
+        "-1943910102": "Parent Name"
     },
     "links": {
         "browserExtension": {
@@ -4203,7 +4209,13 @@
             "title": -192931013,
             "addCustom": -1381310011,
             "deleteGeoArea": -1181081010,
-            "deleteGeoAreaConfirm": -1828391488
+            "deleteGeoAreaConfirm": -1828391488,
+            "adminLevel": -1924381012,
+            "adminLevelName": -1818401301,
+            "idProperty": -1383841901,
+            "propertyName": -14834810210,
+            "idParent": -1948348191,
+            "parentName": -1943910102
         }
     }
 }

--- a/src/typings/project.tsx
+++ b/src/typings/project.tsx
@@ -53,7 +53,7 @@ export interface ProjectDetails {
     title: string;
     isVisualizationEnabled: VisaulizationEnabledOptions;
     versionId: number;
-    regions: BasicElement[];
+    regions: BasicRegion[];
 
     memberStatus: 'admin' | 'member';
     role: number;
@@ -208,4 +208,32 @@ export interface ProjectMemberships {
 
 export interface ProjectRolesMap {
     [key: number]: ProjectRole;
+}
+
+export interface AdminLevel {
+    id: number;
+    title: string;
+    level: number;
+    nameProp: string;
+    codeProp: string;
+    parentNameProp: string;
+    parentCodeProp: string;
+}
+
+export interface BasicRegion {
+    id: number;
+    title: string;
+}
+export interface Region extends BasicRegion {
+    createdAt: string;
+    modifiedAt: string;
+    createdBy: number;
+    modifiedBy: number;
+    createdByName: string;
+    modifiedByName: string;
+    versionId: number;
+    adminLevels: AdminLevel[];
+    code: string;
+    title: string;
+    public: boolean;
 }


### PR DESCRIPTION
- fixes https://github.com/the-deep/client/issues/1781
-  fixes https://github.com/the-deep/client/issues/1782

## Changes

* Add Geo Areas tab to project page
* Display list of geo-areas of project
* Display details of geo-areas that are private to the project

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
