### PR TITLE
Use new form api

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
         "@togglecorp/ravl": "^1.2.3",
         "@togglecorp/re-map": "^0.0.2",
         "@togglecorp/react-rest-request": "^2.5.0-beta.6",
-        "@togglecorp/toggle-form": "^0.2.0-beta.6",
+        "@togglecorp/toggle-form": "^1.0.0",
         "@types/exceljs": "^1.3.0",
         "@types/file-saver": "^2.0.2",
         "@types/react": "^17.0.3",

--- a/src/newComponents/general/AddOrganizationModal/index.tsx
+++ b/src/newComponents/general/AddOrganizationModal/index.tsx
@@ -6,6 +6,7 @@ import {
     urlCondition,
     ObjectSchema,
     requiredStringCondition,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     PendingMessage,
@@ -84,21 +85,23 @@ function AddOrganizationModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(defaultFormValue, organizationSchema);
+        setError,
+    } = useForm(organizationSchema, defaultFormValue);
+
+    const error = getErrorObject(riskyError);
 
     const handleSubmit = useCallback(
         () => {
             const { errored, error: err, value: val } = validate();
-            onErrorSet(err);
+            setError(err);
             if (!errored && isDefined(val)) {
                 createOrganization(val);
             }
         },
-        [onErrorSet, validate, createOrganization],
+        [setError, validate, createOrganization],
     );
     const pending = organizationTypesPending || organizationPostPending;
 
@@ -125,9 +128,9 @@ function AddOrganizationModal(props: Props) {
                 className={styles.input}
                 name="title"
                 disabled={pending}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value?.title}
-                error={error?.fields?.title}
+                error={error?.title}
                 label={_ts('addOrganizationModal', 'titleLabel')}
                 placeholder={_ts('addOrganizationModal', 'titleLabel')}
                 autoFocus
@@ -136,9 +139,9 @@ function AddOrganizationModal(props: Props) {
                 className={styles.input}
                 name="shortName"
                 disabled={pending}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value?.shortName}
-                error={error?.fields?.shortName}
+                error={error?.shortName}
                 label={_ts('addOrganizationModal', 'shortName')}
                 placeholder={_ts('addOrganizationModal', 'shortName')}
             />
@@ -146,19 +149,19 @@ function AddOrganizationModal(props: Props) {
                 className={styles.input}
                 name="url"
                 disabled={pending}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value?.url}
-                error={error?.fields?.url}
+                error={error?.url}
                 label={_ts('addOrganizationModal', 'url')}
                 placeholder={_ts('addOrganizationModal', 'url')}
             />
             <SelectInput
                 className={styles.input}
                 name="organizationType"
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 options={organizatonTypesResponse?.results}
                 value={value?.organizationType}
-                error={error?.fields?.organizationType}
+                error={error?.organizationType}
                 keySelector={organizationTypeKeySelector}
                 labelSelector={organizationTypeLabelSelector}
                 label={_ts('addOrganizationModal', 'organizationType')}

--- a/src/newComponents/general/AddStakeholderModal/index.tsx
+++ b/src/newComponents/general/AddStakeholderModal/index.tsx
@@ -7,8 +7,8 @@ import {
 import {
     useForm,
     ObjectSchema,
-    arrayCondition,
-    StateArg,
+    defaultEmptyArrayType,
+    SetValueArg,
 } from '@togglecorp/toggle-form';
 import {
     Heading,
@@ -33,11 +33,11 @@ type FormSchemaFields = ReturnType<FormSchema['fields']>;
 
 const stakeholdersSchema: FormSchema = {
     fields: (): FormSchemaFields => ({
-        lead_organization: [arrayCondition],
-        international_partner: [arrayCondition],
-        national_partner: [arrayCondition],
-        donor: [arrayCondition],
-        government: [arrayCondition],
+        lead_organization: [defaultEmptyArrayType],
+        international_partner: [defaultEmptyArrayType],
+        national_partner: [defaultEmptyArrayType],
+        donor: [defaultEmptyArrayType],
+        government: [defaultEmptyArrayType],
     }),
 };
 
@@ -45,7 +45,7 @@ export type BasicProjectOrganization = Pick<ProjectOrganization, 'organization' 
 
 export interface Props<T> {
     name: T;
-    onChange: (value: StateArg<BasicProjectOrganization[] | undefined>, name: T) => void;
+    onChange: (value: SetValueArg<BasicProjectOrganization[] | undefined>, name: T) => void;
     options: BasicOrganization[];
     onOptionsChange: (value: BasicOrganization[]) => void;
     value?: BasicProjectOrganization[];
@@ -80,15 +80,15 @@ function AddStakeholderModal<T extends string>(props: Props<T>) {
     const {
         pristine,
         value,
-        onValueChange,
-    } = useForm(initialFormValue, stakeholdersSchema);
+        setFieldValue,
+    } = useForm(stakeholdersSchema, initialFormValue);
 
     const handleChange = useCallback(
         (stakeholders: number[], organizationType) => {
-            onValueChange(() => (
+            setFieldValue(() => (
                 stakeholders
             ), organizationType);
-        }, [onValueChange],
+        }, [setFieldValue],
     );
     const handleSubmitButtonClick = () => {
         const organizations = mapToList(value, (v, key) => {

--- a/src/newComponents/general/ChangePasswordModal/index.tsx
+++ b/src/newComponents/general/ChangePasswordModal/index.tsx
@@ -7,6 +7,8 @@ import {
     requiredCondition,
     lengthGreaterThanCondition,
     lengthSmallerThanCondition,
+    getErrorObject,
+    internal,
 } from '@togglecorp/toggle-form';
 import {
     Button,
@@ -83,11 +85,13 @@ function ChangePasswordModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(defaultFormValue, changePasswordSchema);
+        setError,
+    } = useForm(changePasswordSchema, defaultFormValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending,
@@ -99,19 +103,26 @@ function ChangePasswordModal(props: Props) {
         onSuccess: () => {
             onModalClose();
         },
-        onFailure: (err) => {
-            onErrorSet({ fields: { ...err.value.faramErrors } });
+        onFailure: ({ value: errorValue }) => {
+            const {
+                $internal,
+                ...otherErrors
+            } = errorValue.faramErrors;
+            setError({
+                ...otherErrors,
+                [internal]: $internal,
+            });
         },
         failureHeader: _ts('changePassword', 'title'),
     });
 
     const handleSubmitButtonClick = useCallback(() => {
         const { errored, error: err, value: val } = validate();
-        onErrorSet(err);
+        setError(err);
         if (!errored && isDefined(val)) {
             changePassword({ oldPassword: val.oldPassword, newPassword: val.newPassword });
         }
-    }, [onErrorSet, validate, changePassword]);
+    }, [setError, validate, changePassword]);
 
     return (
         <Modal
@@ -146,9 +157,9 @@ function ChangePasswordModal(props: Props) {
                 label={_ts('changePassword', 'currentPassword')}
                 placeholder={_ts('changePassword', 'currentPassword')}
                 value={value.oldPassword}
-                error={error?.fields?.oldPassword}
+                error={error?.oldPassword}
                 disabled={pending}
-                onChange={onValueChange}
+                onChange={setFieldValue}
             />
             <PasswordInput
                 name="newPassword"
@@ -156,9 +167,9 @@ function ChangePasswordModal(props: Props) {
                 label={_ts('changePassword', 'newPassword')}
                 placeholder={_ts('changePassword', 'newPassword')}
                 value={value.newPassword}
-                error={error?.fields?.newPassword}
+                error={error?.newPassword}
                 disabled={pending}
-                onChange={onValueChange}
+                onChange={setFieldValue}
             />
             <PasswordInput
                 name="confirmPassword"
@@ -166,9 +177,9 @@ function ChangePasswordModal(props: Props) {
                 label={_ts('changePassword', 'retypePassword')}
                 placeholder={_ts('changePassword', 'retypePassword')}
                 value={value.confirmPassword}
-                error={error?.fields?.confirmPassword}
+                error={error?.confirmPassword}
                 disabled={pending}
-                onChange={onValueChange}
+                onChange={setFieldValue}
             />
         </Modal>
     );

--- a/src/newComponents/ui/NonFieldError/index.tsx
+++ b/src/newComponents/ui/NonFieldError/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { _cs } from '@togglecorp/fujs';
+import { _cs, isNotDefined } from '@togglecorp/fujs';
+import { internal } from '@togglecorp/toggle-form';
 
 import styles from './styles.scss';
 
 interface Props {
     className?: string;
-    error?: {
-        $internal?: string | string[];
+    error?: string | {
+        [internal]?: string | string[];
     };
 }
 
@@ -16,13 +17,27 @@ function NonFieldError(props: Props) {
         className,
     } = props;
 
-    if (!error?.$internal) {
+    if (isNotDefined(error)) {
         return null;
     }
 
-    const children: React.ReactNode = Array.isArray(error.$internal)
-        ? error.$internal.join(', ')
-        : error.$internal;
+    if (typeof error === 'string') {
+        return (
+            <div className={_cs(styles.nonFieldError, className)}>
+                {error}
+            </div>
+        );
+    }
+
+    const internalError = error?.[internal];
+
+    if (!internalError) {
+        return null;
+    }
+
+    const children: React.ReactNode = Array.isArray(internalError)
+        ? internalError.join(', ')
+        : internalError;
 
     return (
         <div className={_cs(styles.nonFieldError, className)}>

--- a/src/newViews/AnalysisModule/Analysis/index.tsx
+++ b/src/newViews/AnalysisModule/Analysis/index.tsx
@@ -158,6 +158,11 @@ function Analysis(props: ComponentProps) {
 
     const disabled = pendingAnalysisDelete;
 
+    const handleCloneSuccess = useCallback(() => {
+        triggerAnalysisList();
+        setModalHidden();
+    }, [triggerAnalysisList, setModalHidden]);
+
     return (
         <ContainerCard
             className={_cs(className, styles.analysisItem)}
@@ -319,7 +324,7 @@ function Analysis(props: ComponentProps) {
                     onClose={setModalHidden}
                     projectId={activeProject}
                     analysisId={analysisId}
-                    onClone={triggerAnalysisList}
+                    onClone={handleCloneSuccess}
                 />
             )}
         </ContainerCard>

--- a/src/newViews/AnalysisModule/AnalysisEditModal/PillarAnalysisRow/index.tsx
+++ b/src/newViews/AnalysisModule/AnalysisEditModal/PillarAnalysisRow/index.tsx
@@ -12,7 +12,9 @@ import {
     useFormObject,
     PartialForm,
     Error,
-    StateArg,
+    SetValueArg,
+    getErrorObject,
+    getErrorString,
 } from '@togglecorp/toggle-form';
 
 import {
@@ -46,7 +48,7 @@ export interface Props {
     error: Error<PillarAnalysisFields> | undefined;
     index: number;
     matrixPillars?: MatrixTocElement[];
-    onChange: (value: StateArg<Value>, index: number) => void;
+    onChange: (value: SetValueArg<Value>, index: number) => void;
     onRemove: (index: number) => void;
     usersList: UserMini[];
     value: Value;
@@ -56,7 +58,7 @@ export interface Props {
 function PillarAnalysisRow(props: Props) {
     const {
         className,
-        error,
+        error: riskyError,
         index,
         matrixPillars,
         onChange,
@@ -66,13 +68,15 @@ function PillarAnalysisRow(props: Props) {
         pending,
     } = props;
 
+    const error = getErrorObject(riskyError);
+
     const onFieldChange = useFormObject(index, onChange, defaultValue);
 
     return (
         <div className={_cs(className, styles.pillarAnalysisRow)}>
             <TextInput
                 className={styles.input}
-                error={error?.fields?.title}
+                error={error?.title}
                 label={_ts('analysis.editModal', 'pillarAnalysisTitleLabel')}
                 name="title"
                 onChange={onFieldChange}
@@ -82,7 +86,7 @@ function PillarAnalysisRow(props: Props) {
             />
             <SelectInput
                 className={styles.input}
-                error={error?.fields?.assignee}
+                error={error?.assignee}
                 keySelector={userKeySelector}
                 label={_ts('analysis.editModal', 'pillarAnalysisAssigneeLabel')}
                 labelSelector={userLabelSelector}
@@ -95,7 +99,7 @@ function PillarAnalysisRow(props: Props) {
             />
             <MultiSelectInput
                 className={styles.input}
-                error={error?.fields?.filters?.$internal}
+                error={getErrorString(error?.filters)}
                 keySelector={idSelector}
                 label={_ts('analysis.editModal', 'pillarAnalysisPillarTitle')}
                 labelSelector={labelSelector}

--- a/src/newViews/AnalyticalFramework/AddUserModal/index.tsx
+++ b/src/newViews/AnalyticalFramework/AddUserModal/index.tsx
@@ -7,6 +7,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     Modal,
@@ -89,11 +90,13 @@ function AddUserModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(formValueFromProps, schema);
+        setError,
+    } = useForm(schema, formValueFromProps);
+
+    const error = getErrorObject(riskyError);
 
     const queryForRoles = useMemo(
         () => (isPrivateFramework ? ({ is_default_role: false }) : undefined),
@@ -137,12 +140,12 @@ function AddUserModal(props: Props) {
     const handleSubmit = useCallback(
         () => {
             const { errored, error: err, value: val } = validate();
-            onErrorSet(err);
+            setError(err);
             if (!errored && isDefined(val)) {
                 triggerAddFrameworkMember({ ...val, framework: frameworkId } as ValueToSend);
             }
         },
-        [onErrorSet, validate, triggerAddFrameworkMember, frameworkId],
+        [setError, validate, triggerAddFrameworkMember, frameworkId],
     );
 
     const currentUser = useMemo(() => (userValue ?
@@ -181,10 +184,10 @@ function AddUserModal(props: Props) {
                 name="member"
                 readOnly={isDefined(userValue)}
                 value={value.member}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 options={userOptions ?? currentUser}
                 onOptionsChange={setUserOptions}
-                error={error?.fields?.member}
+                error={error?.member}
                 disabled={pendingRequests}
                 optionsPopupClassName={styles.optionsPopup}
                 label={_ts('analyticalFramework.addUser', 'userLabel')}
@@ -197,11 +200,11 @@ function AddUserModal(props: Props) {
                 keySelector={roleKeySelector}
                 labelSelector={roleLabelSelector}
                 optionsPopupClassName={styles.optionsPopup}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.role}
                 label={_ts('analyticalFramework.addUser', 'roleLabel')}
                 placeholder={_ts('analyticalFramework.addUser', 'selectRolePlaceholder')}
-                error={error?.fields?.role}
+                error={error?.role}
                 disabled={pendingRequests}
             />
         </Modal>

--- a/src/newViews/AnalyticalFramework/FrameworkDetails/FrameworkDetailsForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/FrameworkDetails/FrameworkDetailsForm/index.tsx
@@ -7,6 +7,7 @@ import {
     ObjectSchema,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     Button,
@@ -68,9 +69,9 @@ function FrameworkDetailsForm(props: Props) {
     ] = useState<BasicOrganization[] | undefined | null>();
 
     const initialValue = useMemo(
-        (): PartialFormType | undefined => {
+        (): PartialFormType => {
             if (!analyticalFrameworkFromProps) {
-                return undefined;
+                return defaultFormValues;
             }
             const { title, organization, description } = analyticalFrameworkFromProps;
             return { title, organization, description };
@@ -81,12 +82,14 @@ function FrameworkDetailsForm(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onValueSet,
-        onErrorSet,
-    } = useForm(initialValue ?? defaultFormValues, schema);
+        setValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: frameworkPatchPending,
@@ -98,7 +101,7 @@ function FrameworkDetailsForm(props: Props) {
         body: ctx => ctx,
         onSuccess: (response) => {
             const { title, organization, description } = response;
-            onValueSet({ title, organization, description });
+            setValue({ title, organization, description });
             onSuccess(response);
         },
         failureHeader: _ts('analyticalFramework', 'title'),
@@ -106,11 +109,11 @@ function FrameworkDetailsForm(props: Props) {
 
     const handleSubmit = useCallback(() => {
         const { errored, error: err, value: val } = validate();
-        onErrorSet(err);
+        setError(err);
         if (!errored && isDefined(val)) {
             patchFramework(val);
         }
-    }, [onErrorSet, validate, patchFramework]);
+    }, [setError, validate, patchFramework]);
 
     const projectOrganizations = useMemo(() => (analyticalFrameworkFromProps?.organizationDetails ?
         [analyticalFrameworkFromProps.organizationDetails] : []
@@ -140,9 +143,9 @@ function FrameworkDetailsForm(props: Props) {
                 <div className={styles.details}>
                     <TextInput
                         name="title"
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value.title}
-                        error={error?.fields?.title}
+                        error={error?.title}
                         disabled={pending}
                         label={_ts('analyticalFramework', 'frameworkTitle')}
                         placeholder={_ts('analyticalFramework', 'frameworkTitle')}
@@ -169,10 +172,10 @@ function FrameworkDetailsForm(props: Props) {
                         className={styles.input}
                         name="organization"
                         value={value.organization}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         options={organizationOptions ?? projectOrganizations}
                         onOptionsChange={setOrganizationOptions}
-                        error={error?.fields?.organization}
+                        error={error?.organization}
                         disabled={pending}
                         label={_ts('analyticalFramework', 'associatedOrganization')}
                         placeholder={_ts('analyticalFramework', 'associatedOrganization')}
@@ -181,8 +184,8 @@ function FrameworkDetailsForm(props: Props) {
                         className={styles.input}
                         name="description"
                         value={value.description}
-                        onChange={onValueChange}
-                        error={error?.fields?.description}
+                        onChange={setFieldValue}
+                        error={error?.description}
                         rows={3}
                         disabled={pending}
                         label={_ts('analyticalFramework', 'description')}
@@ -210,7 +213,7 @@ function FrameworkDetailsForm(props: Props) {
                     name="previewImage"
                     value={value.previewImage}
                     image={analyticalFrameworkFromProps?.previewImage}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                 />
             </div>
         </Container>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/DateRangeWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/DateRangeWidgetForm/index.tsx
@@ -9,11 +9,13 @@ import {
     useForm,
     createSubmitHandler,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { DateRangeWidget, PartialForm } from '../../types';
+import { DateRangeWidget } from '../../types';
 import styles from './styles.scss';
 
 type FormType = DateRangeWidget;
@@ -54,11 +56,13 @@ function DateRangeWidgetForm(props: DateRangeWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -77,7 +81,7 @@ function DateRangeWidgetForm(props: DateRangeWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value?.title ?? 'Unnamed'}
@@ -115,15 +119,15 @@ function DateRangeWidgetForm(props: DateRangeWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value?.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/DateWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/DateWidgetForm/index.tsx
@@ -10,15 +10,17 @@ import {
     useForm,
     useFormObject,
     createSubmitHandler,
-    StateArg,
+    SetValueArg,
     Error,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { DateWidget, PartialForm } from '../../types';
+import { DateWidget } from '../../types';
 
 import styles from './styles.scss';
 
@@ -62,16 +64,18 @@ interface DataInputProps<K extends string>{
     name: K;
     value: PartialDataType | undefined;
     error: Error<PartialDataType> | undefined;
-    onChange: (value: StateArg<PartialDataType | undefined>, name: K) => void;
+    onChange: (value: SetValueArg<PartialDataType | undefined>, name: K) => void;
 }
 
 function DataInput<K extends string>(props: DataInputProps<K>) {
     const {
         value,
-        error,
+        error: riskyError,
         onChange,
         name,
     } = props;
+
+    const error = getErrorObject(riskyError);
 
     const onFieldChange = useFormObject(name, onChange, defaultVal);
 
@@ -88,7 +92,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 name="defaultValue"
                 value={value?.defaultValue}
                 onChange={onFieldChange}
-                error={error?.fields?.defaultValue}
+                error={error?.defaultValue}
             />
         </>
     );
@@ -112,11 +116,13 @@ function DateWidgetForm(props: DateWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -135,7 +141,7 @@ function DateWidgetForm(props: DateWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value?.title ?? 'Unnamed'}
@@ -173,21 +179,21 @@ function DateWidgetForm(props: DateWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <DataInput
                     name="data"
                     value={value.data}
-                    onChange={onValueChange}
-                    error={error?.fields?.data}
+                    onChange={setFieldValue}
+                    error={error?.data}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/Matrix2dWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/Matrix2dWidgetForm/index.tsx
@@ -19,18 +19,21 @@ import {
     useFormObject,
     useFormArray,
     createSubmitHandler,
-    StateArg,
+    SetValueArg,
     analyzeErrors,
     Error,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
+
 import { randomString } from '@togglecorp/fujs';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 import SortableList, { NodeRef, Attributes, Listeners } from '#newComponents/ui/SortableList';
 import { reorder } from '#utils/safeCommon';
 
-import { Matrix2dWidget, PartialForm } from '../../types';
+import { Matrix2dWidget } from '../../types';
 import styles from './styles.scss';
 
 const ROWS_LIMIT = 20;
@@ -213,7 +216,7 @@ interface SubRowInputProps {
     className?: string;
     value: PartialSubRowType;
     error: Error<SubRowType> | undefined;
-    onChange: (value: StateArg<PartialSubRowType>, index: number) => void;
+    onChange: (value: SetValueArg<PartialSubRowType>, index: number) => void;
     onRemove: (index: number) => void;
     index: number;
     listeners?: Listeners;
@@ -225,7 +228,7 @@ function SubRowInput(props: SubRowInputProps) {
     const {
         className,
         value,
-        error,
+        error: riskyError,
         onChange,
         onRemove,
         index,
@@ -236,6 +239,8 @@ function SubRowInput(props: SubRowInputProps) {
     } = props;
 
     const onFieldChange = useFormObject(index, onChange, defaultSubRowVal);
+
+    const error = getErrorObject(riskyError);
 
     const errored = analyzeErrors(error);
     const heading = value.label ?? `Sub Row ${index + 1}`;
@@ -281,7 +286,7 @@ function SubRowInput(props: SubRowInputProps) {
                 name="label"
                 value={value.label}
                 onChange={onFieldChange}
-                error={error?.fields?.label}
+                error={error?.label}
             />
             <TextArea
                 // FIXME: use translation
@@ -290,7 +295,7 @@ function SubRowInput(props: SubRowInputProps) {
                 rows={2}
                 value={value.tooltip}
                 onChange={onFieldChange}
-                error={error?.fields?.tooltip}
+                error={error?.tooltip}
             />
         </ExpandableContainer>
     );
@@ -304,7 +309,7 @@ interface RowInputProps {
     className?: string;
     value: PartialRowType;
     error: Error<RowType> | undefined;
-    onChange: (value: StateArg<PartialRowType>, index: number) => void;
+    onChange: (value: SetValueArg<PartialRowType>, index: number) => void;
     onRemove: (index: number) => void;
     index: number;
     listeners?: Listeners;
@@ -316,7 +321,7 @@ function RowInput(props: RowInputProps) {
     const {
         className,
         value,
-        error,
+        error: riskyError,
         onChange,
         onRemove,
         index,
@@ -328,9 +333,12 @@ function RowInput(props: RowInputProps) {
 
     const onFieldChange = useFormObject(index, onChange, defaultRowVal);
 
+    const error = getErrorObject(riskyError);
+    const arrayError = getErrorObject(error?.subRows);
+
     const {
-        onValueChange: onSubRowsChange,
-        onValueRemove: onSubRowsRemove,
+        setValue: onSubRowsChange,
+        removeValue: onSubRowsRemove,
     } = useFormArray('subRows', onFieldChange);
 
     const handleAdd = useCallback(
@@ -371,9 +379,9 @@ function RowInput(props: RowInputProps) {
             value: data,
             onChange: onSubRowsChange,
             onRemove: onSubRowsRemove,
-            error: error?.fields?.subRows?.members?.[key],
+            error: arrayError?.[key],
         }),
-        [onSubRowsChange, onSubRowsRemove, error?.fields?.subRows?.members],
+        [onSubRowsChange, onSubRowsRemove, arrayError],
     );
 
     return (
@@ -417,7 +425,7 @@ function RowInput(props: RowInputProps) {
                 name="label"
                 value={value.label}
                 onChange={onFieldChange}
-                error={error?.fields?.label}
+                error={error?.label}
             />
             <TextArea
                 // FIXME: use translation
@@ -426,7 +434,7 @@ function RowInput(props: RowInputProps) {
                 rows={2}
                 value={value.tooltip}
                 onChange={onFieldChange}
-                error={error?.fields?.tooltip}
+                error={error?.tooltip}
             />
             <Container
                 className={className}
@@ -444,7 +452,7 @@ function RowInput(props: RowInputProps) {
                     </QuickActionButton>
                 )}
             >
-                <NonFieldError error={error?.fields?.subRows} />
+                <NonFieldError error={error?.subRows} />
                 <SortableList
                     name="subRows"
                     onChange={handleSubRowsOrderChange}
@@ -467,7 +475,7 @@ interface SubColumnInputProps {
     className?: string;
     value: PartialSubColumnType;
     error: Error<SubColumnType> | undefined;
-    onChange: (value: StateArg<PartialSubColumnType>, index: number) => void;
+    onChange: (value: SetValueArg<PartialSubColumnType>, index: number) => void;
     onRemove: (index: number) => void;
     index: number;
     listeners?: Listeners;
@@ -479,7 +487,7 @@ function SubColumnInput(props: SubColumnInputProps) {
     const {
         className,
         value,
-        error,
+        error: riskyError,
         onChange,
         onRemove,
         index,
@@ -490,6 +498,8 @@ function SubColumnInput(props: SubColumnInputProps) {
     } = props;
 
     const onFieldChange = useFormObject(index, onChange, defaultSubColumnVal);
+
+    const error = getErrorObject(riskyError);
 
     const errored = analyzeErrors(error);
     const heading = value.label ?? `Sub Column ${index + 1}`;
@@ -535,7 +545,7 @@ function SubColumnInput(props: SubColumnInputProps) {
                 name="label"
                 value={value.label}
                 onChange={onFieldChange}
-                error={error?.fields?.label}
+                error={error?.label}
             />
             <TextArea
                 // FIXME: use translation
@@ -544,7 +554,7 @@ function SubColumnInput(props: SubColumnInputProps) {
                 rows={2}
                 value={value.tooltip}
                 onChange={onFieldChange}
-                error={error?.fields?.tooltip}
+                error={error?.tooltip}
             />
         </ExpandableContainer>
     );
@@ -558,7 +568,7 @@ interface ColumnInputProps {
     className?: string;
     value: PartialColumnType;
     error: Error<ColumnType> | undefined;
-    onChange: (value: StateArg<PartialColumnType>, index: number) => void;
+    onChange: (value: SetValueArg<PartialColumnType>, index: number) => void;
     onRemove: (index: number) => void;
     index: number;
     listeners?: Listeners;
@@ -570,7 +580,7 @@ function ColumnInput(props: ColumnInputProps) {
     const {
         className,
         value,
-        error,
+        error: riskyError,
         onChange,
         onRemove,
         index,
@@ -580,11 +590,14 @@ function ColumnInput(props: ColumnInputProps) {
         style,
     } = props;
 
+    const error = getErrorObject(riskyError);
+    const arrayError = getErrorObject(error?.subColumns);
+
     const onFieldChange = useFormObject(index, onChange, defaultColumnVal);
 
     const {
-        onValueChange: onSubColumnsChange,
-        onValueRemove: onSubColumnsRemove,
+        setValue: onSubColumnsChange,
+        removeValue: onSubColumnsRemove,
     } = useFormArray('subColumns', onFieldChange);
 
     const handleAdd = useCallback(
@@ -625,9 +638,9 @@ function ColumnInput(props: ColumnInputProps) {
             value: data,
             onChange: onSubColumnsChange,
             onRemove: onSubColumnsRemove,
-            error: error?.fields?.subColumns?.members?.[key],
+            error: arrayError?.[key],
         }),
-        [onSubColumnsChange, onSubColumnsRemove, error?.fields?.subColumns?.members],
+        [onSubColumnsChange, onSubColumnsRemove, arrayError],
     );
 
     return (
@@ -671,7 +684,7 @@ function ColumnInput(props: ColumnInputProps) {
                 name="label"
                 value={value.label}
                 onChange={onFieldChange}
-                error={error?.fields?.label}
+                error={error?.label}
             />
             <TextArea
                 // FIXME: use translation
@@ -680,7 +693,7 @@ function ColumnInput(props: ColumnInputProps) {
                 rows={2}
                 value={value.tooltip}
                 onChange={onFieldChange}
-                error={error?.fields?.tooltip}
+                error={error?.tooltip}
             />
             <Container
                 className={className}
@@ -698,7 +711,7 @@ function ColumnInput(props: ColumnInputProps) {
                     </QuickActionButton>
                 )}
             >
-                <NonFieldError error={error?.fields?.subColumns} />
+                <NonFieldError error={error?.subColumns} />
                 <SortableList
                     name="subColumns"
                     onChange={handleSubColumnOrderChange}
@@ -719,23 +732,27 @@ interface DataInputProps<K extends string>{
     name: K;
     value: PartialDataType | undefined;
     error: Error<PartialDataType> | undefined;
-    onChange: (value: StateArg<PartialDataType | undefined>, name: K) => void;
+    onChange: (value: SetValueArg<PartialDataType | undefined>, name: K) => void;
     className?: string;
 }
 function DataInput<K extends string>(props: DataInputProps<K>) {
     const {
         value,
-        error,
+        error: riskyError,
         onChange,
         name,
         className,
     } = props;
 
+    const error = getErrorObject(riskyError);
+    const rowError = getErrorObject(error?.rows);
+    const columnError = getErrorObject(error?.columns);
+
     const onFieldChange = useFormObject(name, onChange, defaultVal);
 
     const {
-        onValueChange: onRowsChange,
-        onValueRemove: onRowsRemove,
+        setValue: onRowsChange,
+        removeValue: onRowsRemove,
     } = useFormArray('rows', onFieldChange);
 
     const handleRowAdd = useCallback(
@@ -760,8 +777,8 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
     );
 
     const {
-        onValueChange: onColumnsChange,
-        onValueRemove: onColumnsRemove,
+        setValue: onColumnsChange,
+        removeValue: onColumnsRemove,
     } = useFormArray('columns', onFieldChange);
 
     const columnRendererParams = useCallback(
@@ -774,9 +791,9 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
             value: data,
             onChange: onColumnsChange,
             onRemove: onColumnsRemove,
-            error: error?.fields?.columns?.members?.[key],
+            error: rowError?.[key],
         }),
-        [onColumnsChange, onColumnsRemove, error?.fields?.columns?.members],
+        [onColumnsChange, onColumnsRemove, rowError],
     );
 
     const rowRendererParams = useCallback(
@@ -789,9 +806,9 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
             value: data,
             onChange: onRowsChange,
             onRemove: onRowsRemove,
-            error: error?.fields?.rows?.members?.[key],
+            error: columnError?.[key],
         }),
-        [onRowsChange, onRowsRemove, error?.fields?.rows?.members],
+        [onRowsChange, onRowsRemove, columnError],
     );
 
     const handleRowsOrderChange = useCallback((newRows: PartialRowType[]) => {
@@ -842,7 +859,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                     </QuickActionButton>
                 )}
             >
-                <NonFieldError error={error?.fields?.rows} />
+                <NonFieldError error={error?.rows} />
                 <SortableList
                     name="rows"
                     onChange={handleRowsOrderChange}
@@ -869,7 +886,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                     </QuickActionButton>
                 )}
             >
-                <NonFieldError error={error?.fields?.columns} />
+                <NonFieldError error={error?.columns} />
                 <SortableList
                     name="columns"
                     onChange={handleColumnsOrderChange}
@@ -902,11 +919,13 @@ function Matrix2dWidgetForm(props: Matrix2dWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -925,7 +944,7 @@ function Matrix2dWidgetForm(props: Matrix2dWidgetFormProps) {
     return (
         <form
             className={styles.widgetEdit}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value.title ?? 'Unnamed'}
@@ -959,14 +978,14 @@ function Matrix2dWidgetForm(props: Matrix2dWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <DataInput
                     name="data"
                     value={value.data}
-                    onChange={onValueChange}
-                    error={error?.fields?.data}
+                    onChange={setFieldValue}
+                    error={error?.data}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/NumberWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/NumberWidgetForm/index.tsx
@@ -10,16 +10,18 @@ import {
     useForm,
     useFormObject,
     createSubmitHandler,
-    StateArg,
+    SetValueArg,
     Error,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import { isTruthy } from '@togglecorp/fujs';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { NumberWidget, PartialForm } from '../../types';
+import { NumberWidget } from '../../types';
 
 import styles from './styles.scss';
 
@@ -72,17 +74,19 @@ interface DataInputProps<K extends string>{
     name: K;
     value: PartialDataType | undefined;
     error: Error<PartialDataType> | undefined;
-    onChange: (value: StateArg<PartialDataType | undefined>, name: K) => void;
+    onChange: (value: SetValueArg<PartialDataType | undefined>, name: K) => void;
 }
 function DataInput<K extends string>(props: DataInputProps<K>) {
     const {
         value,
-        error,
+        error: riskyError,
         onChange,
         name,
     } = props;
 
     const onFieldChange = useFormObject(name, onChange, defaultVal);
+
+    const error = getErrorObject(riskyError);
 
     return (
         <>
@@ -97,7 +101,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 name="defaultValue"
                 value={value?.defaultValue}
                 onChange={onFieldChange}
-                error={error?.fields?.defaultValue}
+                error={error?.defaultValue}
             />
             <NumberInput
                 className={styles.input}
@@ -106,7 +110,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 name="minValue"
                 value={value?.minValue}
                 onChange={onFieldChange}
-                error={error?.fields?.minValue}
+                error={error?.minValue}
             />
             <NumberInput
                 className={styles.input}
@@ -115,7 +119,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 name="maxValue"
                 value={value?.maxValue}
                 onChange={onFieldChange}
-                error={error?.fields?.maxValue}
+                error={error?.maxValue}
             />
         </>
     );
@@ -139,11 +143,13 @@ function NumberWidgetForm(props: NumberWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -162,7 +168,7 @@ function NumberWidgetForm(props: NumberWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value?.title ?? 'Unnamed'}
@@ -200,21 +206,21 @@ function NumberWidgetForm(props: NumberWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <DataInput
                     name="data"
                     value={value.data}
-                    onChange={onValueChange}
-                    error={error?.fields?.data}
+                    onChange={setFieldValue}
+                    error={error?.data}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/SingleSelectWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/SingleSelectWidgetForm/index.tsx
@@ -18,17 +18,19 @@ import {
     useFormObject,
     useFormArray,
     createSubmitHandler,
-    StateArg,
+    SetValueArg,
     analyzeErrors,
     Error,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import { randomString } from '@togglecorp/fujs';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { SingleSelectWidget, PartialForm } from '../../types';
+import { SingleSelectWidget } from '../../types';
 import styles from './styles.scss';
 
 const OPTIONS_LIMIT = 100;
@@ -105,7 +107,7 @@ interface OptionInputProps {
     className?: string;
     value: PartialOptionType;
     error: Error<OptionType> | undefined;
-    onChange: (value: StateArg<PartialOptionType>, index: number) => void;
+    onChange: (value: SetValueArg<PartialOptionType>, index: number) => void;
     onRemove: (index: number) => void;
     index: number;
 }
@@ -114,13 +116,15 @@ function OptionInput(props: OptionInputProps) {
     const {
         className,
         value,
-        error,
+        error: riskyError,
         onChange,
         onRemove,
         index,
     } = props;
 
     const onFieldChange = useFormObject(index, onChange, defaultOptionVal);
+
+    const error = getErrorObject(riskyError);
 
     const errored = analyzeErrors(error);
     const heading = value.label ?? `Option ${index + 1}`;
@@ -150,7 +154,7 @@ function OptionInput(props: OptionInputProps) {
                 name="label"
                 value={value.label}
                 onChange={onFieldChange}
-                error={error?.fields?.label}
+                error={error?.label}
             />
             <TextArea
                 // FIXME: use translation
@@ -159,7 +163,7 @@ function OptionInput(props: OptionInputProps) {
                 rows={2}
                 value={value.tooltip}
                 onChange={onFieldChange}
-                error={error?.fields?.tooltip}
+                error={error?.tooltip}
             />
         </ExpandableContainer>
     );
@@ -171,14 +175,14 @@ interface DataInputProps<K extends string>{
     name: K;
     value: PartialDataType | undefined;
     error: Error<DataType> | undefined;
-    onChange: (value: StateArg<PartialDataType | undefined>, name: K) => void;
+    onChange: (value: SetValueArg<PartialDataType | undefined>, name: K) => void;
     className?: string;
 }
 
 function DataInput<K extends string>(props: DataInputProps<K>) {
     const {
         value,
-        error,
+        error: riskyError,
         onChange,
         name,
         className,
@@ -186,9 +190,12 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
 
     const onFieldChange = useFormObject(name, onChange, defaultVal);
 
+    const error = getErrorObject(riskyError);
+    const arrayError = getErrorObject(error?.options);
+
     const {
-        onValueChange: onOptionsChange,
-        onValueRemove: onOptionsRemove,
+        setValue: onOptionsChange,
+        removeValue: onOptionsRemove,
     } = useFormArray('options', onFieldChange);
 
     const handleAdd = useCallback(
@@ -234,7 +241,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                     </QuickActionButton>
                 )}
             >
-                <NonFieldError error={error?.fields?.options} />
+                <NonFieldError error={error?.options} />
                 {value?.options?.map((option, index) => (
                     <OptionInput
                         key={option.clientId}
@@ -242,7 +249,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                         value={option}
                         onChange={onOptionsChange}
                         onRemove={onOptionsRemove}
-                        error={error?.fields?.options?.members?.[option.clientId]}
+                        error={arrayError?.[option.clientId]}
                     />
                 ))}
             </Container>
@@ -268,11 +275,13 @@ function SingleSelectWidgetForm(props: SingleSelectWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -291,7 +300,7 @@ function SingleSelectWidgetForm(props: SingleSelectWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value.title ?? 'Unnamed'}
@@ -326,21 +335,21 @@ function SingleSelectWidgetForm(props: SingleSelectWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
                 <DataInput
                     name="data"
                     value={value.data}
-                    onChange={onValueChange}
-                    error={error?.fields?.data}
+                    onChange={setFieldValue}
+                    error={error?.data}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/TextWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/TextWidgetForm/index.tsx
@@ -9,15 +9,17 @@ import {
     useForm,
     useFormObject,
     createSubmitHandler,
-    StateArg,
+    SetValueArg,
     Error,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { TextWidget, PartialForm } from '../../types';
+import { TextWidget } from '../../types';
 import styles from './styles.scss';
 
 type FormType = TextWidget;
@@ -60,17 +62,19 @@ interface DataInputProps<K extends string>{
     name: K;
     value: PartialDataType | undefined;
     error: Error<PartialDataType> | undefined;
-    onChange: (value: StateArg<PartialDataType | undefined>, name: K) => void;
+    onChange: (value: SetValueArg<PartialDataType | undefined>, name: K) => void;
 }
 function DataInput<K extends string>(props: DataInputProps<K>) {
     const {
         value,
-        error,
+        error: riskyError,
         onChange,
         name,
     } = props;
 
     const onFieldChange = useFormObject(name, onChange, defaultVal);
+
+    const error = getErrorObject(riskyError);
 
     return (
         <>
@@ -85,7 +89,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 name="defaultValue"
                 value={value?.defaultValue}
                 onChange={onFieldChange}
-                error={error?.fields?.defaultValue}
+                error={error?.defaultValue}
             />
         </>
     );
@@ -109,11 +113,13 @@ function TextWidgetForm(props: TextWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -132,7 +138,7 @@ function TextWidgetForm(props: TextWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value?.title ?? 'Unnamed'}
@@ -169,21 +175,21 @@ function TextWidgetForm(props: TextWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <DataInput
                     name="data"
                     value={value.data}
-                    onChange={onValueChange}
-                    error={error?.fields?.data}
+                    onChange={setFieldValue}
+                    error={error?.data}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/TimeRangeWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/TimeRangeWidgetForm/index.tsx
@@ -9,12 +9,14 @@ import {
     useForm,
     createSubmitHandler,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { TimeRangeWidget, PartialForm } from '../../types';
+import { TimeRangeWidget } from '../../types';
 import styles from './styles.scss';
 
 type FormType = TimeRangeWidget;
@@ -57,11 +59,13 @@ function TimeRangeWidgetForm(props: TimeRangeWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -80,7 +84,7 @@ function TimeRangeWidgetForm(props: TimeRangeWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value?.title ?? 'Unnamed'}
@@ -118,15 +122,15 @@ function TimeRangeWidgetForm(props: TimeRangeWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value?.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/TimeWidgetForm/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/TimeWidgetForm/index.tsx
@@ -9,15 +9,17 @@ import {
     useForm,
     useFormObject,
     createSubmitHandler,
-    StateArg,
+    SetValueArg,
     Error,
     requiredStringCondition,
+    PartialForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
 
 import WidgetSizeInput from '../../WidgetSizeInput';
-import { TimeWidget, PartialForm } from '../../types';
+import { TimeWidget } from '../../types';
 
 import styles from './styles.scss';
 
@@ -61,18 +63,20 @@ interface DataInputProps<K extends string>{
     name: K;
     value: PartialDataType | undefined;
     error: Error<PartialDataType> | undefined;
-    onChange: (value: StateArg<PartialDataType | undefined>, name: K) => void;
+    onChange: (value: SetValueArg<PartialDataType | undefined>, name: K) => void;
 }
 
 function DataInput<K extends string>(props: DataInputProps<K>) {
     const {
         value,
-        error,
+        error: riskyError,
         onChange,
         name,
     } = props;
 
     const onFieldChange = useFormObject(name, onChange, defaultVal);
+
+    const error = getErrorObject(riskyError);
 
     return (
         <>
@@ -87,7 +91,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 name="defaultValue"
                 value={value?.defaultValue}
                 onChange={onFieldChange}
-                error={error?.fields?.defaultValue}
+                error={error?.defaultValue}
             />
         </>
     );
@@ -111,11 +115,13 @@ function TimeWidgetForm(props: TimeWidgetFormProps) {
     const {
         pristine,
         value,
-        error,
+        error: riskyError,
         validate,
-        onValueChange,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setFieldValue,
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     useEffect(
         () => {
@@ -134,7 +140,7 @@ function TimeWidgetForm(props: TimeWidgetFormProps) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 heading={value?.title ?? 'Unnamed'}
@@ -172,21 +178,21 @@ function TimeWidgetForm(props: TimeWidgetFormProps) {
                     name="title"
                     autoFocus
                     value={value.title}
-                    onChange={onValueChange}
-                    error={error?.fields?.title}
+                    onChange={setFieldValue}
+                    error={error?.title}
                 />
                 <DataInput
                     name="data"
                     value={value.data}
-                    onChange={onValueChange}
-                    error={error?.fields?.data}
+                    onChange={setFieldValue}
+                    error={error?.data}
                 />
                 <WidgetSizeInput
                     name="width"
                     className={styles.input}
                     value={value.width}
-                    onChange={onValueChange}
-                    error={error?.fields?.width}
+                    onChange={setFieldValue}
+                    error={error?.width}
                 />
             </Container>
         </form>

--- a/src/newViews/AnalyticalFramework/WidgetEditor/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetEditor/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
+import { PartialForm } from '@togglecorp/toggle-form';
 
-import { Widget, PartialForm } from '../types';
+import { Widget } from '../types';
 import TextWidgetForm from './TextWidgetForm';
 import NumberWidgetForm from './NumberWidgetForm';
 import DateWidgetForm from './DateWidgetForm';

--- a/src/newViews/AnalyticalFramework/WidgetPreview/Matrix1dWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/Matrix1dWidgetInput/index.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback } from 'react';
 import { Button, List } from '@the-deep/deep-ui';
+import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
 
-import { Matrix1dValue, Matrix1dWidget, PartialForm } from '../../types';
+import { Matrix1dValue, Matrix1dWidget } from '../../types';
 import WidgetWrapper from '../../Widget';
 
 import styles from './styles.scss';

--- a/src/newViews/AnalyticalFramework/WidgetPreview/Matrix2dWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/Matrix2dWidgetInput/index.tsx
@@ -5,11 +5,12 @@ import {
     Heading,
     List,
 } from '@the-deep/deep-ui';
+import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
 import { sortByOrder } from '#utils/safeCommon';
 
-import { Matrix2dValue, Matrix2dWidget, PartialForm } from '../../types';
+import { Matrix2dValue, Matrix2dWidget } from '../../types';
 import WidgetWrapper from '../../Widget';
 
 import styles from './styles.scss';

--- a/src/newViews/AnalyticalFramework/WidgetPreview/MultiSelectWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/MultiSelectWidgetInput/index.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import {
     MultiSelectInput,
 } from '@the-deep/deep-ui';
+import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
 
-import { MultiSelectValue, MultiSelectWidget, PartialForm } from '../../types';
+import { MultiSelectValue, MultiSelectWidget } from '../../types';
 import WidgetWrapper from '../../Widget';
 
 export type PartialMultiSelectWidget = PartialForm<

--- a/src/newViews/AnalyticalFramework/WidgetPreview/ScaleWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/ScaleWidgetInput/index.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import {
     ScaleInput,
 } from '@the-deep/deep-ui';
+import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
 
-import { ScaleValue, ScaleWidget, PartialForm } from '../../types';
+import { ScaleValue, ScaleWidget } from '../../types';
 import WidgetWrapper from '../../Widget';
 
 export type PartialScaleWidget = PartialForm<

--- a/src/newViews/AnalyticalFramework/WidgetPreview/SingleSelectWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/SingleSelectWidgetInput/index.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import {
     SelectInput,
 } from '@the-deep/deep-ui';
+import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
 
-import { SingleSelectValue, SingleSelectWidget, PartialForm } from '../../types';
+import { SingleSelectValue, SingleSelectWidget } from '../../types';
 import WidgetWrapper from '../../Widget';
 
 export type PartialSingleSelectWidget = PartialForm<

--- a/src/newViews/AnalyticalFramework/WidgetPreview/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
 
-import { Widget, PartialForm } from '../types';
+import { Widget } from '../types';
 import TextWidgetInput, { Props as TextWidgetInputProps } from './TextWidgetInput';
 import DateWidgetInput, { Props as DateWidgetInputProps } from './DateWidgetInput';
 import Matrix1dWidgetInput, { Props as Matrix1dWidgetInputProps } from './Matrix1dWidgetInput';

--- a/src/newViews/AnalyticalFramework/types.ts
+++ b/src/newViews/AnalyticalFramework/types.ts
@@ -1,19 +1,3 @@
-type Intersects<A, B> = A extends B ? true : never;
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type PartialForm<T, J extends string> = T extends object ? (
-    T extends (infer K)[] ? (
-        PartialForm<K, J>[]
-    ) : (
-        Intersects<J, keyof T> extends true ? (
-            { [P in Exclude<keyof T, J>]?: PartialForm<T[P], J> }
-            & Pick<T, keyof T & J>
-        ) : (
-            { [P in keyof T]?: PartialForm<T[P], J> }
-        )
-    )
-) : T;
-
 export type NumberValue = number;
 export type TextValue = string;
 export type DateValue = string;

--- a/src/newViews/Explore/ForgotPasswordModal/index.tsx
+++ b/src/newViews/Explore/ForgotPasswordModal/index.tsx
@@ -64,9 +64,7 @@ function ForgotPasswordModal(props: Props) {
     const [success, setSuccess] = useState(false);
 
     const initialValue = useMemo(
-        (): FormType => ({
-            email,
-        } ?? defaultFormValue),
+        (): FormType => (email ? { email } : defaultFormValue),
         [email],
     );
 

--- a/src/newViews/Explore/LoginRegisterModal/LoginForm/index.tsx
+++ b/src/newViews/Explore/LoginRegisterModal/LoginForm/index.tsx
@@ -20,6 +20,8 @@ import {
     lengthGreaterThanCondition,
     requiredStringCondition,
     lengthSmallerThanCondition,
+    internal,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import Captcha from '@hcaptcha/react-hcaptcha';
 import { parseUrlParams } from '@togglecorp/react-rest-request';
@@ -135,11 +137,13 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(initialValue, mySchema);
+        setError,
+    } = useForm(mySchema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: loginPending,
@@ -154,20 +158,22 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
             authenticate();
         },
         onFailure: ({ errorCode, value: errorValue }) => {
+            const {
+                $internal,
+                ...otherErrors
+            } = errorValue.faramErrors;
             if (errorCode === 4004) {
-                onErrorSet({
-                    fields: {
-                        ...errorValue.faramErrors,
-                    },
-                    $internal: captchaRequired
+                setError({
+                    ...otherErrors,
+                    [internal]: captchaRequired
                         ? _ts('explore.login', 'retryRecaptcha')
                         : _ts('explore.login', 'enterRecaptcha'),
                 });
                 setCaptchaRequired(true);
             } else {
-                onErrorSet({
-                    fields: { ...errorValue.faramErrors },
-                    $internal: errorValue.faramErrors.$internal,
+                setError({
+                    ...otherErrors,
+                    [internal]: $internal,
                 });
             }
         },
@@ -187,20 +193,22 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
             authenticate();
         },
         onFailure: ({ errorCode, value: errorValue }) => {
+            const {
+                $internal,
+                ...otherErrors
+            } = errorValue.faramErrors;
             if (errorCode === 4004) {
-                onErrorSet({
-                    fields: {
-                        ...errorValue.faramErrors,
-                    },
-                    $internal: captchaRequired
+                setError({
+                    ...otherErrors,
+                    [internal]: captchaRequired
                         ? _ts('explore.login', 'retryRecaptcha')
                         : _ts('explore.login', 'enterRecaptcha'),
                 });
                 setCaptchaRequired(true);
             } else {
-                onErrorSet({
-                    fields: { ...errorValue.faramErrors },
-                    $internal: errorValue.faramErrors.$internal,
+                setError({
+                    ...otherErrors,
+                    [internal]: $internal,
                 });
             }
         },
@@ -235,7 +243,7 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
     return (
         <form
             className={_cs(styles.loginForm, className)}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             {pending && <PendingMessage />}
             <Container
@@ -247,8 +255,8 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
                         name="hcaptchaResponse"
                         elementRef={elementRef}
                         siteKey={HCaptchaSiteKey}
-                        onChange={onValueChange}
-                        error={error?.fields?.hcaptchaResponse}
+                        onChange={setFieldValue}
+                        error={error?.hcaptchaResponse}
                     />
                 )}
                 footerActions={(
@@ -282,9 +290,9 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
                     <TextInput
                         name="username"
                         className={styles.input}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.username}
-                        error={error?.fields?.username}
+                        error={error?.username}
                         label={_ts('explore.login', 'emailLabel')}
                         placeholder={_ts('explore.login', 'emailPlaceholder')}
                         disabled={pending}
@@ -293,9 +301,9 @@ function LoginRegisterModal(props: Props & PropsFromDispatch) {
                     <PasswordInput
                         name="password"
                         className={styles.input}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.password}
-                        error={error?.fields?.password}
+                        error={error?.password}
                         label={_ts('explore.login', 'password')}
                         placeholder={_ts('explore.login', 'password')}
                         disabled={pending}

--- a/src/newViews/Explore/LoginRegisterModal/RegisterForm/index.tsx
+++ b/src/newViews/Explore/LoginRegisterModal/RegisterForm/index.tsx
@@ -13,6 +13,8 @@ import {
     createSubmitHandler,
     requiredCondition,
     requiredStringCondition,
+    internal,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import Captcha from '@hcaptcha/react-hcaptcha';
 import { useLazyRequest } from '#utils/request';
@@ -61,11 +63,13 @@ function RegisterModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(initialValue, schema);
+        setError,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: registerPending,
@@ -79,17 +83,19 @@ function RegisterModal(props: Props) {
             setSuccess(true);
         },
         onFailure: ({ errorCode, value: errorValue }) => {
+            const {
+                $internal,
+                ...otherErrors
+            } = errorValue.faramErrors;
             if (errorCode === 4004) {
-                onErrorSet({
-                    fields: {
-                        ...errorValue.faramErrors,
-                    },
-                    $internal: _ts('explore.register', 'retryRecaptcha'),
+                setError({
+                    ...otherErrors,
+                    [internal]: _ts('explore.register', 'retryRecaptcha'),
                 });
             } else {
-                onErrorSet({
-                    fields: { ...errorValue.faramErrors },
-                    $internal: errorValue.faramErrors.$internal,
+                setError({
+                    ...otherErrors,
+                    [internal]: $internal,
                 });
             }
         },
@@ -104,7 +110,7 @@ function RegisterModal(props: Props) {
     return (
         <form
             className={_cs(styles.registerForm, className)}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             {registerPending && <PendingMessage />}
             {success ? (
@@ -122,8 +128,8 @@ function RegisterModal(props: Props) {
                             name="hcaptchaResponse"
                             elementRef={elementRef}
                             siteKey={HCaptchaSiteKey}
-                            onChange={onValueChange}
-                            error={error?.fields?.hcaptchaResponse}
+                            onChange={setFieldValue}
+                            error={error?.hcaptchaResponse}
                             disabled={registerPending}
                         />
                     )}
@@ -145,9 +151,9 @@ function RegisterModal(props: Props) {
                     <TextInput
                         name="firstName"
                         className={styles.input}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.firstName}
-                        error={error?.fields?.firstName}
+                        error={error?.firstName}
                         label={_ts('explore.register', 'firstNameLabel')}
                         placeholder={_ts('explore.register', 'firstNamePlaceholder')}
                         disabled={registerPending}
@@ -155,9 +161,9 @@ function RegisterModal(props: Props) {
                     <TextInput
                         name="lastName"
                         className={styles.input}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.lastName}
-                        error={error?.fields?.lastName}
+                        error={error?.lastName}
                         label={_ts('explore.register', 'lastNameLabel')}
                         placeholder={_ts('explore.register', 'lastNamePlaceholder')}
                         disabled={registerPending}
@@ -165,9 +171,9 @@ function RegisterModal(props: Props) {
                     <TextInput
                         name="organization"
                         className={styles.input}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.organization}
-                        error={error?.fields?.organization}
+                        error={error?.organization}
                         label={_ts('explore.register', 'organizationLabel')}
                         placeholder={_ts('explore.register', 'organizationPlaceholder')}
                         disabled={registerPending}
@@ -175,9 +181,9 @@ function RegisterModal(props: Props) {
                     <TextInput
                         name="username"
                         className={styles.input}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.username}
-                        error={error?.fields?.username}
+                        error={error?.username}
                         label={_ts('explore.register', 'emailLabel')}
                         placeholder={_ts('explore.register', 'emailPlaceholder')}
                         disabled={registerPending}

--- a/src/newViews/MyProfile/index.tsx
+++ b/src/newViews/MyProfile/index.tsx
@@ -15,8 +15,9 @@ import {
     requiredStringCondition,
     useForm,
     createSubmitHandler,
-    arrayCondition,
+    defaultEmptyArrayType,
     requiredCondition,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import Avatar from '#newComponents/ui/Avatar';
@@ -64,7 +65,7 @@ const schema: FormSchema = {
         lastName: [requiredStringCondition],
         organization: [],
         language: [requiredCondition],
-        emailOptOuts: [arrayCondition],
+        emailOptOuts: [defaultEmptyArrayType],
     }),
 };
 
@@ -107,12 +108,14 @@ function MyProfile(props: Props & PropsFromDispatch) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
-    } = useForm(initialValue, schema);
+        setError,
+        setValue,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: userGetPending,
@@ -120,8 +123,8 @@ function MyProfile(props: Props & PropsFromDispatch) {
         url: `server://users/${activeUser.userId}/`,
         method: 'GET',
         onSuccess: (response: User) => {
-            onValueSet(response);
-            onErrorSet({});
+            setValue(response);
+            setError({});
             setUserInformation({
                 userId: activeUser.userId,
                 information: response,
@@ -146,8 +149,8 @@ function MyProfile(props: Props & PropsFromDispatch) {
         method: 'PATCH',
         body: ctx => ctx,
         onSuccess: (response) => {
-            onValueSet(response);
-            onErrorSet({});
+            setValue(response);
+            setError({});
             setUserInformation({
                 userId: activeUser.userId,
                 information: response,
@@ -158,15 +161,15 @@ function MyProfile(props: Props & PropsFromDispatch) {
 
     const handleCheck = useCallback((checked: boolean, name: EmailOptOut) => {
         if (checked) {
-            onValueChange((oldValue: EmailOptOut[] | undefined) => ([
+            setFieldValue((oldValue: EmailOptOut[] | undefined) => ([
                 ...(oldValue ?? []),
                 name]), 'emailOptOuts' as const);
         } else {
-            onValueChange((oldValue: EmailOptOut[] | undefined) => ([
+            setFieldValue((oldValue: EmailOptOut[] | undefined) => ([
                 ...(oldValue ?? []).filter(v => v !== name),
             ]), 'emailOptOuts' as const);
         }
-    }, [onValueChange]);
+    }, [setFieldValue]);
 
     const rowRendererParams = useCallback((key: EmailOptOut, data: EmailOptOutOption) => ({
         name: key,
@@ -181,7 +184,7 @@ function MyProfile(props: Props & PropsFromDispatch) {
     return (
         <form
             className={styles.form}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
                 className={styles.myProfile}
@@ -220,9 +223,9 @@ function MyProfile(props: Props & PropsFromDispatch) {
                             <TextInput
                                 name="firstName"
                                 disabled={disabled}
-                                onChange={onValueChange}
+                                onChange={setFieldValue}
                                 value={value?.firstName}
-                                error={error?.fields?.firstName}
+                                error={error?.firstName}
                                 label={_ts('myProfile', 'firstName')}
                                 placeholder={_ts('myProfile', 'firstName')}
                                 autoFocus
@@ -230,18 +233,18 @@ function MyProfile(props: Props & PropsFromDispatch) {
                             <TextInput
                                 name="lastName"
                                 disabled={disabled}
-                                onChange={onValueChange}
+                                onChange={setFieldValue}
                                 value={value?.lastName}
-                                error={error?.fields?.lastName}
+                                error={error?.lastName}
                                 label={_ts('myProfile', 'lastName')}
                                 placeholder={_ts('myProfile', 'lastName')}
                             />
                             <TextInput
                                 name="organization"
                                 disabled={disabled}
-                                onChange={onValueChange}
+                                onChange={setFieldValue}
                                 value={value?.organization}
-                                error={error?.fields?.organization}
+                                error={error?.organization}
                                 label={_ts('myProfile', 'organization')}
                                 placeholder={_ts('myProfile', 'organization')}
                             />
@@ -257,9 +260,9 @@ function MyProfile(props: Props & PropsFromDispatch) {
                             <SelectInput
                                 name="language"
                                 disabled={disabled}
-                                onChange={onValueChange}
+                                onChange={setFieldValue}
                                 value={value?.language}
-                                error={error?.fields?.language}
+                                error={error?.language}
                                 label={_ts('myProfile', 'platformLanguage')}
                                 placeholder={_ts('myProfile', 'platformLanguage')}
                                 keySelector={langaugeKeySelector}

--- a/src/newViews/PillarAnalysis/AnalyticalStatementInput/index.tsx
+++ b/src/newViews/PillarAnalysis/AnalyticalStatementInput/index.tsx
@@ -21,8 +21,9 @@ import {
 import {
     useFormArray,
     useFormObject,
-    StateArg,
+    SetValueArg,
     Error,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
@@ -49,7 +50,7 @@ interface AnalyticalStatementInputProps {
     className?: string;
     value: PartialAnalyticalStatementType;
     error: Error<AnalyticalStatementType> | undefined;
-    onChange: (value: StateArg<PartialAnalyticalStatementType>, index: number) => void;
+    onChange: (value: SetValueArg<PartialAnalyticalStatementType>, index: number) => void;
     onRemove: (index: number) => void;
     onEntryMove: (entryId: number, statementClientId: string) => void;
     onEntryDrop: (entryId: number) => void;
@@ -70,7 +71,7 @@ function AnalyticalStatementInput(props: AnalyticalStatementInputProps) {
     const {
         className,
         value,
-        error,
+        error: riskyError,
         onChange,
         onRemove,
         onEntryMove,
@@ -84,9 +85,12 @@ function AnalyticalStatementInput(props: AnalyticalStatementInputProps) {
 
     const onFieldChange = useFormObject(index, onChange, defaultVal);
 
+    const error = getErrorObject(riskyError);
+    const arrayError = getErrorObject(error?.analyticalEntries);
+
     const {
-        // onValueChange: onAnalyticalEntryChange,
-        onValueRemove: onAnalyticalEntryRemove,
+        // setValue: onAnalyticalEntryChange,
+        removeValue: onAnalyticalEntryRemove,
     } = useFormArray('analyticalEntries', onFieldChange);
 
     type AnalyticalEntry = typeof value.analyticalEntries;
@@ -228,7 +232,7 @@ function AnalyticalStatementInput(props: AnalyticalStatementInputProps) {
                         rows={4}
                         value={value.statement}
                         onChange={onFieldChange}
-                        error={error?.fields?.statement}
+                        error={error?.statement}
                     />
                 </div>
                 <div className={styles.bottomContainer}>
@@ -241,8 +245,7 @@ function AnalyticalStatementInput(props: AnalyticalStatementInputProps) {
                                 value={analyticalEntry}
                                 // onChange={onAnalyticalEntryChange}
                                 onRemove={onAnalyticalEntryRemove}
-                                // eslint-disable-next-line max-len
-                                error={error?.fields?.analyticalEntries?.members?.[analyticalEntry.clientId]}
+                                error={arrayError?.[analyticalEntry.clientId]}
                                 onAnalyticalEntryDrop={handleAnalyticalEntryDrop}
                             />
                         ))}

--- a/src/newViews/PillarAnalysis/EntriesFilterForm/FrameworkFilter/index.tsx
+++ b/src/newViews/PillarAnalysis/EntriesFilterForm/FrameworkFilter/index.tsx
@@ -38,7 +38,7 @@ interface Props {
     geoOptions?: GeoOptions;
     className?: string;
     value: FaramValues;
-    onValueChange: (...entries: EntriesAsList<FaramValues>) => void;
+    onChange: (...entries: EntriesAsList<FaramValues>) => void;
 }
 
 function FrameworkFilter(props: Props) {
@@ -49,7 +49,7 @@ function FrameworkFilter(props: Props) {
         geoOptions = emptyGeoOptions,
         className,
         value,
-        onValueChange,
+        onChange: setFieldValue,
     } = props;
 
     if (!filter?.type) {
@@ -63,7 +63,7 @@ function FrameworkFilter(props: Props) {
                 <GeoMultiSelectInput
                     name={filterKey}
                     value={value?.[filterKey] as (string[] | undefined)}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     className={_cs(styles.frameworkFilter, className)}
                     label={title}
                     options={options}
@@ -77,7 +77,7 @@ function FrameworkFilter(props: Props) {
                 <MultiSelectInput
                     name={filterKey}
                     value={value?.[filterKey] as (string[] | undefined)}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     label={title}
                     options={filter.options}
                     keySelector={filterKeySelector}
@@ -111,7 +111,7 @@ function FrameworkFilter(props: Props) {
                 <TextInput
                     name={filterKey}
                     value={value?.[filterKey] as (string | undefined)}
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     label={title}
                     placeholder={_ts('entries', 'textSearchPlaceholder')}
                     className={_cs(styles.frameworkFilter, className)}

--- a/src/newViews/PillarAnalysis/EntriesFilterForm/index.tsx
+++ b/src/newViews/PillarAnalysis/EntriesFilterForm/index.tsx
@@ -14,6 +14,7 @@ import {
     ObjectSchema,
     useForm,
     createSubmitHandler,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import { useRequest } from '#utils/request';
@@ -135,15 +136,15 @@ function EntriesFilterForm(props: OwnProps) {
     const {
         pristine,
         validate,
-        onErrorSet,
+        setError,
         value,
-        onValueSet,
-        onValueChange,
-    } = useForm(initialValue, schema);
+        setValue,
+        setFieldValue,
+    } = useForm(schema, initialValue);
 
     useEffect(() => {
-        onValueSet(filtersValue ?? initialValue);
-    }, [filtersValue, onValueSet]);
+        setValue(filtersValue ?? initialValue);
+    }, [filtersValue, setValue]);
 
     const isFilterEmpty = useMemo(() => (
         doesObjectHaveNoData(value, [''])
@@ -171,13 +172,13 @@ function EntriesFilterForm(props: OwnProps) {
             regions,
             geoOptions,
             value,
-            onValueChange,
+            onChange: setFieldValue,
             className: _cs(
                 styles.filter,
                 isMatrixFilter && styles.showFilter,
             ),
         });
-    }, [regions, geoOptions, value, onValueChange]);
+    }, [regions, geoOptions, value, setFieldValue]);
 
     const handleClearFilters = useCallback(() => {
         onFiltersValueChange({});
@@ -196,7 +197,7 @@ function EntriesFilterForm(props: OwnProps) {
                 styles.entriesFilterForm,
                 allFiltersVisible && styles.showFilters,
             )}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <MultiSelectInput
                 className={styles.filter}
@@ -204,7 +205,7 @@ function EntriesFilterForm(props: OwnProps) {
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 value={value?.created_by as (string[] | undefined)}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 options={entryOptions?.createdBy}
                 label={_ts('pillarAnalysis', 'createdByFilterLabel')}
                 placeholder={_ts('pillarAnalysis', 'createdByPlaceholder')}
@@ -219,7 +220,7 @@ function EntriesFilterForm(props: OwnProps) {
                 className={styles.filter}
                 name="comment_assignee"
                 value={value?.comment_assignee as (string[] | undefined)}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 options={entryOptions?.createdBy}
@@ -230,7 +231,7 @@ function EntriesFilterForm(props: OwnProps) {
                 className={styles.filter}
                 name="comment_created_by"
                 value={value?.comment_created_by as (string[] | undefined)}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 options={entryOptions?.createdBy}
@@ -242,7 +243,7 @@ function EntriesFilterForm(props: OwnProps) {
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 value={value?.comment_status as (string | undefined)}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 name="comment_status"
                 options={commentStatusOptions}
                 label={_ts('pillarAnalysis', 'commentStatusOptionsFilterLabel')}
@@ -252,7 +253,7 @@ function EntriesFilterForm(props: OwnProps) {
                 className={styles.filter}
                 name="verified"
                 value={value?.verified as (string | undefined)}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 options={verificationStatusOptions}
@@ -263,7 +264,7 @@ function EntriesFilterForm(props: OwnProps) {
                 className={styles.filter}
                 name="entry_type"
                 value={value?.entry_type as (string[] | undefined)}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 options={entryTypeOptions}

--- a/src/newViews/PillarAnalysis/EntriesFilterForm/index.tsx
+++ b/src/newViews/PillarAnalysis/EntriesFilterForm/index.tsx
@@ -14,7 +14,6 @@ import {
     ObjectSchema,
     useForm,
     createSubmitHandler,
-    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import { useRequest } from '#utils/request';

--- a/src/newViews/PillarAnalysis/schema.ts
+++ b/src/newViews/PillarAnalysis/schema.ts
@@ -2,31 +2,31 @@ import {
     ObjectSchema,
     PartialForm,
     ArraySchema,
-    idCondition,
+    defaultUndefinedType,
     requiredCondition,
     requiredStringCondition,
 } from '@togglecorp/toggle-form';
 import { AnalysisPillars } from '#typings';
 
 export type FormType = Pick<AnalysisPillars, 'mainStatement' | 'informationGap' | 'analyticalStatements'>;
-export type PartialFormType = PartialForm<FormType, { clientId: string }>;
+export type PartialFormType = PartialForm<FormType, 'clientId'>;
 
 type FormSchema = ObjectSchema<PartialFormType>;
 type FormSchemaFields = ReturnType<FormSchema['fields']>;
 
 export type AnalyticalStatementType = NonNullable<NonNullable<FormType['analyticalStatements']>>[number];
 export type PartialAnalyticalStatementType = PartialForm<
-    AnalyticalStatementType, { clientId: string }
+    AnalyticalStatementType, 'clientId'
 >;
 
 export type AnalyticalEntryType = NonNullable<NonNullable<AnalyticalStatementType['analyticalEntries']>>[number];
-export type PartialAnalyticalEntryType = PartialForm<AnalyticalEntryType, { clientId: string }>;
+export type PartialAnalyticalEntryType = PartialForm<AnalyticalEntryType, 'clientId'>;
 
 type AnalyticalEntrySchema = ObjectSchema<PartialAnalyticalEntryType>;
 type AnalyticalEntrySchemaFields = ReturnType<AnalyticalEntrySchema['fields']>;
 const analyticalEntrySchema: AnalyticalEntrySchema = {
     fields: (): AnalyticalEntrySchemaFields => ({
-        id: [idCondition],
+        id: [defaultUndefinedType],
         clientId: [],
         order: [],
         entry: [requiredCondition],
@@ -45,7 +45,7 @@ type AnalyticalStatementSchema = ObjectSchema<PartialAnalyticalStatementType>;
 type AnalyticalStatementSchemaFields = ReturnType<AnalyticalStatementSchema['fields']>;
 const analyticalStatementSchema: AnalyticalStatementSchema = {
     fields: (): AnalyticalStatementSchemaFields => ({
-        id: [idCondition],
+        id: [defaultUndefinedType],
         clientId: [],
         order: [],
         statement: [requiredStringCondition],

--- a/src/newViews/ProjectEdit/Framework/AddFrameworkModal/index.tsx
+++ b/src/newViews/ProjectEdit/Framework/AddFrameworkModal/index.tsx
@@ -15,6 +15,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import { useLazyRequest } from '#utils/request';
@@ -81,11 +82,13 @@ function AddFrameworkModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(formValueFromProps, schema);
+        setError,
+    } = useForm(schema, formValueFromProps);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: pendingAddAction,
@@ -111,12 +114,12 @@ function AddFrameworkModal(props: Props) {
     const handleSubmit = useCallback(
         () => {
             const { errored, error: err, value: val } = validate();
-            onErrorSet(err);
+            setError(err);
             if (!errored && isDefined(val)) {
                 triggerCreateFramework(val as ValueToSend);
             }
         },
-        [onErrorSet, validate, triggerCreateFramework],
+        [setError, validate, triggerCreateFramework],
     );
 
     const pendingRequests = pendingAddAction;
@@ -147,22 +150,22 @@ function AddFrameworkModal(props: Props) {
             <TextInput
                 name="title"
                 className={styles.input}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.title}
                 label={_ts('projectEdit', 'titleLabel')}
                 placeholder={_ts('projectEdit', 'titlePlaceholder')}
-                error={error?.fields?.title}
+                error={error?.title}
                 disabled={pendingRequests}
             />
             <TextArea
                 name="description"
                 rows={5}
                 className={styles.input}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.description}
                 label={_ts('projectEdit', 'descriptionLabel')}
                 placeholder={_ts('projectEdit', 'descriptionPlaceholder')}
-                error={error?.fields?.description}
+                error={error?.description}
                 disabled={pendingRequests}
             />
         </Modal>

--- a/src/newViews/ProjectEdit/Framework/index.tsx
+++ b/src/newViews/ProjectEdit/Framework/index.tsx
@@ -19,7 +19,6 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
-    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import {

--- a/src/newViews/ProjectEdit/Framework/index.tsx
+++ b/src/newViews/ProjectEdit/Framework/index.tsx
@@ -19,6 +19,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import {
@@ -162,8 +163,8 @@ function ProjectFramework(props: Props) {
 
     const {
         value,
-        onValueChange,
-    } = useForm(defaultFormValue, schema);
+        setFieldValue,
+    } = useForm(schema, defaultFormValue);
 
     const delayedValue = useDebouncedValue(value);
 
@@ -217,7 +218,7 @@ function ProjectFramework(props: Props) {
                     <SelectInput
                         name="relatedToMe"
                         className={styles.filter}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         options={frameworkFilterOptions}
                         keySelector={relatedToMeKeySelector}
                         labelSelector={relatedToMeLabelSelector}
@@ -227,7 +228,7 @@ function ProjectFramework(props: Props) {
                     <TextInput
                         name="search"
                         className={styles.filter}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value.search}
                         label={_ts('projectEdit', 'searchLabel')}
                         placeholder={_ts('projectEdit', 'searchPlaceholder')}

--- a/src/newViews/ProjectEdit/ProjectDetailsForm/RequestPrivateProjectButton/index.tsx
+++ b/src/newViews/ProjectEdit/ProjectDetailsForm/RequestPrivateProjectButton/index.tsx
@@ -3,6 +3,7 @@ import { IoChevronForward } from 'react-icons/io5';
 import {
     useForm,
     ObjectSchema,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     ButtonLikeLink,
@@ -52,15 +53,17 @@ function RequestPrivateProjectButton(props: Props) {
 
     const {
         value,
-        error,
-        onValueSet,
-        onValueChange,
-    } = useForm(defaultFormValue, formSchema);
+        error: riskyError,
+        setValue,
+        setFieldValue,
+    } = useForm(formSchema, defaultFormValue);
+
+    const error = getErrorObject(riskyError);
 
     const handleClose = useCallback(() => {
-        onValueSet({});
+        setValue({});
         hideModal();
-    }, [onValueSet, hideModal]);
+    }, [setValue, hideModal]);
 
     return (
         <>
@@ -101,9 +104,9 @@ function RequestPrivateProjectButton(props: Props) {
                     <TextInput
                         className={styles.input}
                         name="description"
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value.description}
-                        error={error?.fields?.description}
+                        error={error?.description}
                         label={_ts('requestPrivateProject', 'description')}
                         placeholder={_ts('requestPrivateProject', 'descriptionPlaceholder')}
                         autoFocus
@@ -113,8 +116,8 @@ function RequestPrivateProjectButton(props: Props) {
                         name="justification"
                         rows={4}
                         value={value.justification}
-                        error={error?.fields?.justification}
-                        onChange={onValueChange}
+                        error={error?.justification}
+                        onChange={setFieldValue}
                         label={_ts('requestPrivateProject', 'justification')}
                         placeholder={_ts('requestPrivateProject', 'justificationPlaceholder')}
                     />

--- a/src/newViews/ProjectEdit/ProjectDetailsForm/index.tsx
+++ b/src/newViews/ProjectEdit/ProjectDetailsForm/index.tsx
@@ -23,10 +23,11 @@ import {
     ArraySchema,
     ObjectSchema,
     requiredStringCondition,
-    idCondition,
+    defaultUndefinedType,
     useForm,
     createSubmitHandler,
     requiredCondition,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import NonFieldError from '#newComponents/ui/NonFieldError';
@@ -131,7 +132,7 @@ const organizationListSchema: StakeholderListSchema = {
 
 const schema: FormSchema = {
     fields: (): FormSchemaFields => ({
-        id: [idCondition],
+        id: [defaultUndefinedType],
         title: [requiredStringCondition],
         startDate: [],
         endDate: [],
@@ -183,28 +184,30 @@ function ProjectDetailsForm(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
-    } = useForm(initialValue, schema);
+        setError,
+        setValue,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     const [projectDetails, setProjectDetails] = useState<ProjectDetails | undefined>();
     const [stakeholderOptions, setStakeholderOptions] = useState<BasicOrganization[]>([]);
 
     useEffect(
         () => {
-            onValueSet((): FormType => (
+            setValue((): FormType => (
                 projectDetails ? {
                     ...projectDetails,
                     isPrivate: projectDetails.isPrivate.toString(),
                     organizations: getOrganizationValues(projectDetails),
                 } : initialValue
             ));
-            onErrorSet({});
+            setError({});
         },
-        [projectDetails, onErrorSet, onValueSet],
+        [projectDetails, setError, setValue],
     );
 
     const {
@@ -217,7 +220,7 @@ function ProjectDetailsForm(props: Props) {
             setProjectDetails(response);
             const options = getOrganizationOptions(response);
             setStakeholderOptions(options);
-            onErrorSet({});
+            setError({});
         },
         failureHeader: _ts('projectEdit', 'projectDetailsLabel'),
     });
@@ -278,7 +281,7 @@ function ProjectDetailsForm(props: Props) {
     return (
         <form
             className={styles.projectDetails}
-            onSubmit={createSubmitHandler(validate, onErrorSet, handleSubmit)}
+            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             {(pending || projectPatchPending) && <PendingMessage />}
             <NonFieldError error={error} />
@@ -288,9 +291,9 @@ function ProjectDetailsForm(props: Props) {
                         className={styles.input}
                         name="title"
                         disabled={disabled}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.title}
-                        error={error?.fields?.title}
+                        error={error?.title}
                         label={_ts('projectEdit', 'projectTitle')}
                         placeholder={_ts('projectEdit', 'projectTitle')}
                         autoFocus
@@ -300,9 +303,9 @@ function ProjectDetailsForm(props: Props) {
                             className={styles.dateInput}
                             name="startDate"
                             disabled={disabled}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             value={value?.startDate}
-                            error={error?.fields?.startDate}
+                            error={error?.startDate}
                             label={_ts('projectEdit', 'projectStartDate')}
                             placeholder={_ts('projectEdit', 'projectStartDate')}
                         />
@@ -310,9 +313,9 @@ function ProjectDetailsForm(props: Props) {
                             className={styles.dateInput}
                             name="endDate"
                             disabled={disabled}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             value={value?.endDate}
-                            error={error?.fields?.endDate}
+                            error={error?.endDate}
                             label={_ts('projectEdit', 'projectEndDate')}
                             placeholder={_ts('projectEdit', 'projectEndDate')}
                         />
@@ -321,9 +324,9 @@ function ProjectDetailsForm(props: Props) {
                         className={styles.input}
                         name="description"
                         disabled={disabled}
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         value={value?.description}
-                        error={error?.fields?.description}
+                        error={error?.description}
                         label={_ts('projectEdit', 'projectDescription')}
                         placeholder={_ts('projectEdit', 'projectDescription')}
                         rows={4}
@@ -341,7 +344,7 @@ function ProjectDetailsForm(props: Props) {
                             options={projectVisibilityOptions}
                             keySelector={projectVisibilityKeySelector}
                             labelSelector={projectVisibilityLabelSelector}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             disabled={isDefined(projectId) || !accessPrivateProject}
                         />
                         { !accessPrivateProject && !isDefined(projectId) && (
@@ -359,9 +362,9 @@ function ProjectDetailsForm(props: Props) {
                         <Checkbox
                             name="hasAssessments"
                             disabled={disabled}
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             value={value?.hasAssessments}
-                            // error={error?.fields?.hasAssessments}
+                            // error={error?.hasAssessments}
                             label={_ts('projectEdit', 'projectAssessmentRegistry')}
                         />
                     </Container>
@@ -374,7 +377,7 @@ function ProjectDetailsForm(props: Props) {
                             <AddStakeholderButton
                                 name="organizations"
                                 value={value?.organizations}
-                                onChange={onValueChange}
+                                onChange={setFieldValue}
                                 onOptionsChange={setStakeholderOptions}
                                 options={stakeholderOptions}
                             />

--- a/src/newViews/ProjectEdit/Users/UserGroupList/AddUserGroupModal/index.tsx
+++ b/src/newViews/ProjectEdit/Users/UserGroupList/AddUserGroupModal/index.tsx
@@ -8,6 +8,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     Modal,
@@ -96,11 +97,13 @@ function AddUserGroupModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(formValue, schema);
+        setError,
+    } = useForm(schema, formValue);
+
+    const error = getErrorObject(riskyError);
 
     const queryForUsergroups = useMemo(() => ({
         members_exclude_project: projectId,
@@ -146,12 +149,12 @@ function AddUserGroupModal(props: Props) {
     const handleSubmit = useCallback(
         () => {
             const { errored, error: err, value: val } = validate();
-            onErrorSet(err);
+            setError(err);
             if (!errored && isDefined(val)) {
                 triggerAddUserGroup(val as ValueToSend);
             }
         },
-        [onErrorSet, validate, triggerAddUserGroup],
+        [setError, validate, triggerAddUserGroup],
     );
 
     const usergroupList = useMemo(() => {
@@ -208,9 +211,9 @@ function AddUserGroupModal(props: Props) {
                 keySelector={usergroupKeySelector}
                 labelSelector={usergroupLabelSelector}
                 optionsPopupClassName={styles.optionsPopup}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.usergroup}
-                error={error?.fields?.usergroup}
+                error={error?.usergroup}
                 label={_ts('projectEdit', 'usergroupLabel')}
                 placeholder={_ts('projectEdit', 'selectUsergroupPlaceholder')}
             />
@@ -221,9 +224,9 @@ function AddUserGroupModal(props: Props) {
                 keySelector={roleKeySelector}
                 labelSelector={roleLabelSelector}
                 optionsPopupClassName={styles.optionsPopup}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.role}
-                error={error?.fields?.role}
+                error={error?.role}
                 label={_ts('projectEdit', 'roleLabel')}
                 placeholder={_ts('projectEdit', 'selectRolePlaceholder')}
             />

--- a/src/newViews/ProjectEdit/Users/UserList/AddUserModal/index.tsx
+++ b/src/newViews/ProjectEdit/Users/UserList/AddUserModal/index.tsx
@@ -7,6 +7,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     Modal,
@@ -83,11 +84,13 @@ function AddUserModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(formValueFromProps, schema);
+        setError,
+    } = useForm(schema, formValueFromProps);
+
+    const error = getErrorObject(riskyError);
 
     const queryForUsers = useMemo(() => ({
         members_exclude_project: projectId,
@@ -128,12 +131,12 @@ function AddUserModal(props: Props) {
     const handleSubmit = useCallback(
         () => {
             const { errored, error: err, value: val } = validate();
-            onErrorSet(err);
+            setError(err);
             if (!errored && isDefined(val)) {
                 triggerAddProjectMember(val as ValueToSend);
             }
         },
-        [onErrorSet, validate, triggerAddProjectMember],
+        [setError, validate, triggerAddProjectMember],
     );
 
     const currentUser = useMemo(() => (userValue ?
@@ -178,10 +181,10 @@ function AddUserModal(props: Props) {
                 name="member"
                 readOnly={isDefined(userValue)}
                 value={value.member}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 options={userOptions ?? currentUser}
                 onOptionsChange={setUserOptions}
-                error={error?.fields?.member}
+                error={error?.member}
                 disabled={pendingRequests}
                 optionsPopupClassName={styles.optionsPopup}
                 label={_ts('projectEdit', 'userLabel')}
@@ -194,7 +197,7 @@ function AddUserModal(props: Props) {
                 keySelector={roleKeySelector}
                 labelSelector={roleLabelSelector}
                 optionsPopupClassName={styles.optionsPopup}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.role}
                 label={_ts('projectEdit', 'roleLabel')}
                 placeholder={_ts('projectEdit', 'selectRolePlaceholder')}

--- a/src/newViews/Tagging/Sources/SourcesFilter/index.tsx
+++ b/src/newViews/Tagging/Sources/SourcesFilter/index.tsx
@@ -7,6 +7,8 @@ import {
 import {
     useForm,
     ObjectSchema,
+    getErrorString,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import {
     TextInput,
@@ -122,25 +124,27 @@ function SourcesFilter(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-        onValueSet,
-    } = useForm(initialValue, schema);
+        setError,
+        setValue,
+    } = useForm(schema, initialValue);
+
+    const error = getErrorObject(riskyError);
 
     const handleApply = useCallback(() => {
         const { errored, error: err, value: val } = validate();
-        onErrorSet(err);
+        setError(err);
         if (!errored && isDefined(val)) {
             onFilterApply(val);
         }
-    }, [onErrorSet, validate, onFilterApply]);
+    }, [setError, validate, onFilterApply]);
 
     const handleClear = useCallback(() => {
-        onValueSet(initialValue);
+        setValue(initialValue);
         onFilterApply(initialValue);
-    }, [onValueSet, onFilterApply]);
+    }, [setValue, onFilterApply]);
 
     const [
         showContent,,,,
@@ -170,21 +174,21 @@ function SourcesFilter(props: Props) {
                 <MultiSelectInput
                     className={styles.input}
                     name="status"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     options={leadOptions?.status}
                     keySelector={keySelector}
                     labelSelector={labelSelector}
                     value={value.status}
-                    error={error?.fields?.status?.$internal}
+                    error={getErrorString(error?.status)}
                     label={_ts('sourcesFilter', 'status')}
                     placeholder={_ts('sourcesFilter', 'status')}
                 />
                 <DateInput
                     className={styles.input}
                     name="publishedOn"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     value={value.publishedOn}
-                    error={error?.fields?.publishedOn}
+                    error={error?.publishedOn}
                     disabled={disabled}
                     label={_ts('sourcesFilter', 'originalDate')}
                     placeholder={_ts('sourcesFilter', 'originalDate')}
@@ -192,9 +196,9 @@ function SourcesFilter(props: Props) {
                 <DateInput
                     className={styles.input}
                     name="createdAt"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     value={value.createdAt}
-                    error={error?.fields?.createdAt}
+                    error={error?.createdAt}
                     disabled={disabled}
                     label={_ts('sourcesFilter', 'addedOn')}
                     placeholder={_ts('sourcesFilter', 'addedOn')}
@@ -202,12 +206,12 @@ function SourcesFilter(props: Props) {
                 <MultiSelectInput
                     className={styles.input}
                     name="assignee"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     options={leadOptions?.assignee}
                     keySelector={keySelector}
                     labelSelector={labelSelector}
                     value={value.assignee}
-                    error={error?.fields?.assignee?.$internal}
+                    error={getErrorString(error?.assignee)}
                     label={_ts('sourcesFilter', 'assignee')}
                     placeholder={_ts('sourcesFilter', 'assignee')}
                 />
@@ -215,9 +219,9 @@ function SourcesFilter(props: Props) {
                     className={styles.input}
                     icons={<IoSearch />}
                     name="search"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     value={value.search}
-                    error={error?.fields?.search}
+                    error={error?.search}
                     disabled={disabled}
                     label={_ts('sourcesFilter', 'search')}
                     placeholder={_ts('sourcesFilter', 'search')}
@@ -228,12 +232,12 @@ function SourcesFilter(props: Props) {
                         !showContent && styles.hidden,
                     )}
                     name="exists"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     options={existsFilterOptions}
                     keySelector={keySelector}
                     labelSelector={labelSelector}
                     value={value.exists}
-                    error={error?.fields?.exists}
+                    error={error?.exists}
                     label={_ts('sourcesFilter', 'exists')}
                     placeholder={_ts('sourcesFilter', 'exists')}
                 />
@@ -243,12 +247,12 @@ function SourcesFilter(props: Props) {
                         !showContent && styles.hidden,
                     )}
                     name="priority"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     options={leadOptions?.priority}
                     keySelector={keySelector}
                     labelSelector={labelSelector}
                     value={value.priority}
-                    error={error?.fields?.priority?.$internal}
+                    error={getErrorString(error?.priority)}
                     label={_ts('sourcesFilter', 'priority')}
                     placeholder={_ts('sourcesFilter', 'priority')}
                 />
@@ -258,12 +262,12 @@ function SourcesFilter(props: Props) {
                         !showContent && styles.hidden,
                     )}
                     name="authoringOrganizationTypes"
-                    onChange={onValueChange}
+                    onChange={setFieldValue}
                     options={leadOptions?.organizationTypes}
                     keySelector={keySelector}
                     labelSelector={labelSelector}
                     value={value.authoringOrganizationTypes}
-                    error={error?.fields?.authoringOrganizationTypes?.$internal}
+                    error={getErrorString(error?.authoringOrganizationTypes)}
                     label={_ts('sourcesFilter', 'authoringOrganizationTypes')}
                     placeholder={_ts('sourcesFilter', 'authoringOrganizationTypes')}
                 />
@@ -274,12 +278,12 @@ function SourcesFilter(props: Props) {
                             !showContent && styles.hidden,
                         )}
                         name="confidentiality"
-                        onChange={onValueChange}
+                        onChange={setFieldValue}
                         options={leadOptions?.confidentiality}
                         keySelector={keySelector}
                         labelSelector={labelSelector}
                         value={value.confidentiality}
-                        error={error?.fields?.confidentiality?.$internal}
+                        error={getErrorString(error?.confidentiality)}
                         label={_ts('sourcesFilter', 'confidentiality')}
                         placeholder={_ts('sourcesFilter', 'confidentiality')}
                     />
@@ -292,12 +296,12 @@ function SourcesFilter(props: Props) {
                                 !showContent && styles.hidden,
                             )}
                             name="emmRiskFactors"
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             options={leadOptions?.emmRiskFactors}
                             keySelector={emmKeySelector}
                             labelSelector={emmLabelSelector}
                             value={value.emmRiskFactors}
-                            error={error?.fields?.emmRiskFactors?.$internal}
+                            error={getErrorString(error?.emmRiskFactors)}
                             label={_ts('sourcesFilter', 'emmRiskFactors')}
                             placeholder={_ts('sourcesFilter', 'emmRiskFactors')}
                         />
@@ -307,12 +311,12 @@ function SourcesFilter(props: Props) {
                                 !showContent && styles.hidden,
                             )}
                             name="emmKeywords"
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             options={leadOptions?.emmKeywords}
                             keySelector={emmKeySelector}
                             labelSelector={emmLabelSelector}
                             value={value.emmKeywords}
-                            error={error?.fields?.emmKeywords?.$internal}
+                            error={getErrorString(error?.emmKeywords)}
                             label={_ts('sourcesFilter', 'emmKeywords')}
                             placeholder={_ts('sourcesFilter', 'emmKeywords')}
                         />
@@ -322,12 +326,12 @@ function SourcesFilter(props: Props) {
                                 !showContent && styles.hidden,
                             )}
                             name="emmEntities"
-                            onChange={onValueChange}
+                            onChange={setFieldValue}
                             options={leadOptions?.emmEntities}
                             keySelector={emmKeySelector}
                             labelSelector={emmLabelSelector}
                             value={value.emmEntities}
-                            error={error?.fields?.emmEntities?.$internal}
+                            error={getErrorString(error?.emmEntities)}
                             label={_ts('sourcesFilter', 'emmEntities')}
                             placeholder={_ts('sourcesFilter', 'emmEntities')}
                         />

--- a/src/newViews/UserGroup/AddUserModal/index.tsx
+++ b/src/newViews/UserGroup/AddUserModal/index.tsx
@@ -13,6 +13,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import _ts from '#ts';
@@ -93,11 +94,13 @@ function AddUserModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(formValue, schema);
+        setError,
+    } = useForm(schema, formValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: pendingAddMember,
@@ -119,11 +122,11 @@ function AddUserModal(props: Props) {
 
     const handleSubmit = useCallback(() => {
         const { errored, error: err, value: val } = validate();
-        onErrorSet(err);
+        setError(err);
         if (!errored && isDefined(val)) {
             triggerAddMember(val as FormType);
         }
-    }, [onErrorSet, validate, triggerAddMember]);
+    }, [setError, validate, triggerAddMember]);
 
     return (
         <Modal
@@ -150,13 +153,13 @@ function AddUserModal(props: Props) {
                 className={styles.input}
                 name="member"
                 value={value.member}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 options={isDefined(userToEdit)
                     ? memberOptions
                     : userOptions
                 }
                 onOptionsChange={setUserOptions}
-                error={error?.fields?.member}
+                error={error?.member}
                 disabled={pendingAddMember || isDefined(userToEdit)}
                 label={_ts('usergroup.memberEditModal', 'addMemberLabel')}
                 placeholder={_ts('usergroup.memberEditModal', 'addMemberPlaceholderLabel')}
@@ -168,9 +171,9 @@ function AddUserModal(props: Props) {
                 keySelector={keySelector}
                 options={roles}
                 placeholder={_ts('usergroup.memberEditModal', 'roleLabel')}
-                onChange={onValueChange}
+                onChange={setFieldValue}
                 value={value.role}
-                error={error?.fields?.role}
+                error={error?.role}
                 disabled={pendingAddMember}
             />
         </Modal>

--- a/src/newViews/UserGroup/AddUsergroupModal/index.tsx
+++ b/src/newViews/UserGroup/AddUsergroupModal/index.tsx
@@ -11,6 +11,7 @@ import {
     PartialForm,
     requiredCondition,
     useForm,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 
 import { useLazyRequest } from '#utils/request';
@@ -81,11 +82,13 @@ function AddUsergroupModal(props: Props) {
     const {
         pristine,
         value,
-        error,
-        onValueChange,
+        error: riskyError,
+        setFieldValue,
         validate,
-        onErrorSet,
-    } = useForm(initialFormValue, schema);
+        setError,
+    } = useForm(schema, initialFormValue);
+
+    const error = getErrorObject(riskyError);
 
     const {
         pending: pendingAddUsergroup,
@@ -106,11 +109,11 @@ function AddUsergroupModal(props: Props) {
     });
     const handleSubmit = useCallback(() => {
         const { errored, error: err, value: val } = validate();
-        onErrorSet(err);
+        setError(err);
         if (!errored && isDefined(val)) {
             triggerAddUsergroup(val as UsergroupAdd);
         }
-    }, [onErrorSet, validate, triggerAddUsergroup]);
+    }, [setError, validate, triggerAddUsergroup]);
 
     return (
         <Modal
@@ -133,8 +136,8 @@ function AddUsergroupModal(props: Props) {
             <TextInput
                 name="title"
                 value={value.title}
-                error={error?.fields?.title}
-                onChange={onValueChange}
+                error={error?.title}
+                onChange={setFieldValue}
                 label={_ts('usergroup.editModal', 'usergroupTitleLabel')}
                 placeholder={_ts('usergroup.editModal', 'usergroupTitlePlaceholder')}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,10 @@
     abort-controller "^3.0.0"
     hoist-non-react-statics "^3.3.0"
 
-"@togglecorp/toggle-form@^0.2.0-beta.6":
-  version "0.2.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-form/-/toggle-form-0.2.0-beta.6.tgz#c5cf140ad2c2607e4c3c5448edd08d0390c6c780"
-  integrity sha512-sZCJPbyy5StVdmTQGTWtD/TqVgRc/it1pLVJCgFc5Ocxik1bo22GTVqdf4Fwf42iVp7ZXQpzIRt46eL0iRPPwg==
+"@togglecorp/toggle-form@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@togglecorp/toggle-form/-/toggle-form-1.0.0.tgz#79ac1eadeb384e9aefb91282f969cb0692faaea2"
+  integrity sha512-gGQZ76OjSovFO172w3qTq6efgDteGJtxganxkPKP4UJLnSPuqeWyrnkRorhS5hbik9BNZ0nQS1p+qIgGWaGV8Q==
   dependencies:
     "@babel/runtime-corejs3" "^7.11.2"
     "@storybook/client-api" "^6.0.21"


### PR DESCRIPTION
# Changes

NOTE: Almost all changes should be inside either newComponents or newViews

* Uses new form
- Rename type StateArg to SetValueArg
- Rename useForm's onPristineSet to setPristine
- Rename useForm's onErrorSet to setError
- Rename useForm's onValueSet to setValue
- Rename useForm's onValueChange to setFieldValue
- Rename useFormArray's onValueChange to setValue
- Rename useFormArray's onValureRemove to removeValue
- Rename idCondition to defaultUndefinedType
- Rename nullCondition to forceNullType
- Rename arrayCondition to defaultEmptyArrayType
- Use PartialForm type from toggle-form
- Remove `fields?.` and `members?.` when accessing errors
- Swap `schema` and `value` positional arguments on useForm
- Rename `$internal` to `[internal]`
- Use getErrorObject before accessing error from form
- Use getErrorString before passing to leaf (array or objects)

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments

## This PR contains valid:

- [ ] permission checks
- [ ] translations
