### PR TITLE
Add ordering in ScaleInput Widget

### DIFF
--- a/src/newViews/AnalyticalFramework/PrimaryTagging/SectionsEditor/index.tsx
+++ b/src/newViews/AnalyticalFramework/PrimaryTagging/SectionsEditor/index.tsx
@@ -361,7 +361,7 @@ function SectionsEditor(props: Props) {
                     <>
                         <NonFieldError error={error?.sections} />
                         <SortableList
-                            name="analyticalStatements"
+                            name="sections"
                             onChange={handleOrderChange}
                             data={value.sections}
                             keySelector={sectionKeySelector}

--- a/src/newViews/AnalyticalFramework/WidgetPreview/ScaleWidgetInput/index.tsx
+++ b/src/newViews/AnalyticalFramework/WidgetPreview/ScaleWidgetInput/index.tsx
@@ -1,17 +1,18 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
     ScaleInput,
 } from '@the-deep/deep-ui';
 import { PartialForm } from '@togglecorp/toggle-form';
 
 import { NodeRef } from '#newComponents/ui/SortableList';
+import { sortByOrder } from '#utils/safeCommon';
 
 import { ScaleValue, ScaleWidget } from '../../types';
 import WidgetWrapper from '../../Widget';
 
 export type PartialScaleWidget = PartialForm<
     ScaleWidget,
-    'clientId' | 'type'
+    'clientId' | 'type' | 'order'
 >;
 
 type Option = NonNullable<NonNullable<
@@ -55,6 +56,10 @@ function ScaleWidgetInput<N extends string>(props: Props<N>) {
         rootStyle,
     } = props;
 
+    const sortedOptions = useMemo(() => (
+        sortByOrder(widget?.data?.options)
+    ), [widget?.data?.options]);
+
     return (
         <WidgetWrapper
             className={className}
@@ -65,7 +70,7 @@ function ScaleWidgetInput<N extends string>(props: Props<N>) {
         >
             <ScaleInput
                 name={name}
-                options={widget?.data?.options}
+                options={sortedOptions}
                 keySelector={optionKeySelector}
                 labelSelector={optionLabelSelector}
                 colorSelector={optionColorSelector}


### PR DESCRIPTION
- Addresses #1808

## Changes

* Add ordering in ScaleIput widget


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

