### PR TITLE
Add response error to form error transformer

### DIFF
--- a/src/newViews/PillarAnalysis/AnalyticalStatementInput/AnalyticalEntryInput/index.tsx
+++ b/src/newViews/PillarAnalysis/AnalyticalStatementInput/AnalyticalEntryInput/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@the-deep/deep-ui';
 import {
     Error,
+    getErrorObject,
 } from '@togglecorp/toggle-form';
 import { _cs } from '@togglecorp/fujs';
 
@@ -35,7 +36,7 @@ interface AnalyticalEntryInputProps {
 function AnalyticalEntryInput(props: AnalyticalEntryInputProps) {
     const {
         value,
-        error,
+        error: riskyError,
         // onChange,
         onRemove,
         index,
@@ -43,6 +44,8 @@ function AnalyticalEntryInput(props: AnalyticalEntryInputProps) {
         onAnalyticalEntryDrop,
         dropDisabled,
     } = props;
+
+    const error = getErrorObject(riskyError);
 
     const [
         entryDraggedStatus,
@@ -105,6 +108,7 @@ function AnalyticalEntryInput(props: AnalyticalEntryInputProps) {
                 )}
             >
                 <NonFieldError error={error} />
+                <NonFieldError error={error?.entry} />
                 {entry && (
                     <EntryItem
                         excerpt={entry.excerpt}

--- a/src/newViews/PillarAnalysis/EntriesFilterForm/index.tsx
+++ b/src/newViews/PillarAnalysis/EntriesFilterForm/index.tsx
@@ -13,7 +13,6 @@ import {
 import {
     ObjectSchema,
     useForm,
-    createSubmitHandler,
 } from '@togglecorp/toggle-form';
 
 import { useRequest } from '#utils/request';
@@ -134,8 +133,6 @@ function EntriesFilterForm(props: OwnProps) {
 
     const {
         pristine,
-        validate,
-        setError,
         value,
         setValue,
         setFieldValue,
@@ -185,7 +182,9 @@ function EntriesFilterForm(props: OwnProps) {
 
     const pending = entryOptionsPending;
 
-    const handleSubmit = useCallback(() => {
+    const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
         onFiltersValueChange(value);
     }, [onFiltersValueChange, value]);
 
@@ -196,7 +195,7 @@ function EntriesFilterForm(props: OwnProps) {
                 styles.entriesFilterForm,
                 allFiltersVisible && styles.showFilters,
             )}
-            onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
+            onSubmit={handleSubmit}
         >
             <MultiSelectInput
                 className={styles.filter}

--- a/src/newViews/PillarAnalysis/index.tsx
+++ b/src/newViews/PillarAnalysis/index.tsx
@@ -37,6 +37,7 @@ import BackLink from '#newComponents/ui/BackLink';
 import LoadingAnimation from '#rscv/LoadingAnimation';
 import { processEntryFilters } from '#entities/entries';
 import NonFieldError from '#newComponents/ui/NonFieldError';
+import { transformErrorToToggleFormError } from '#rest';
 
 import notify from '#notify';
 import { useRequest, useLazyRequest } from '#utils/request';
@@ -327,6 +328,11 @@ function PillarAnalysis(props: Props) {
                 message: _ts('pillarAnalysis', 'pillarAnalysisUpdateSuccess'),
                 duration: notify.duration.MEDIUM,
             });
+        },
+        onFailure: (response, ctx) => {
+            if (response.value.errors) {
+                setError(transformErrorToToggleFormError(schema, ctx, response.value.errors));
+            }
         },
         failureHeader: _ts('pillarAnalysis', 'pillarAnalysisTitle'),
     });

--- a/src/rest/index.js
+++ b/src/rest/index.js
@@ -4,6 +4,16 @@ import {
     commonHeaderForGet,
     commonHeaderForPost,
 } from '#config/rest';
+import {
+    listToMap,
+    mapToMap,
+    doesObjectHaveNoData,
+    isNotDefined,
+    isDefined,
+} from '@togglecorp/fujs';
+import {
+    internal,
+} from '@togglecorp/toggle-form';
 
 export * from './analysisFramework';
 export * from './assessmentRegistry';
@@ -81,3 +91,98 @@ export const alterResponseErrorToFaramError = (errors) => {
 export const alterAndCombineResponseError = errors => (
     Object.values(alterResponseErrorToFaramError(errors))
 );
+
+// NOTE: the functions below are generic transformers to
+// transform server error to form error
+
+function transform(formSchema, responseValue, responseError) {
+    if (!formSchema || !responseError) {
+        return undefined;
+    }
+
+    if (Array.isArray(formSchema)) {
+        if (responseError.length <= 0) {
+            return undefined;
+        }
+        return responseError.join(' ');
+    }
+
+    if (formSchema.member && formSchema.keySelector) {
+        // FIXME: there may be a case where the error can be similar to leaf
+
+        const errorList = responseError.map((error, i) => {
+            if (!error) {
+                return undefined;
+            }
+
+            const valueItem = responseValue?.[i];
+            if (isNotDefined(valueItem)) {
+                return undefined;
+            }
+
+            const key = formSchema.keySelector(valueItem);
+            const localSchema = formSchema.member(valueItem);
+
+            const transformedValue = transform(
+                localSchema,
+                valueItem,
+                error,
+            );
+            return { key, transformedValue };
+        }).filter(isDefined);
+
+        const errorMap = listToMap(
+            errorList,
+            error => error.key,
+            error => error.transformedValue,
+        );
+
+        return doesObjectHaveNoData(errorMap)
+            ? undefined
+            : errorMap;
+    }
+
+    if (formSchema.fields) {
+        const objectSchema = formSchema.fields(responseValue);
+
+        // FIXME: how does this map with array error?
+        const {
+            nonFieldErrors,
+            ...otherErrors
+        } = responseError;
+
+        // FIXME: there may be a case where the error can be similar to leaf
+
+        const errorMap = mapToMap(
+            otherErrors,
+            key => key,
+            (err, key) => {
+                const localSchema = objectSchema?.[key];
+                const valueItem = responseValue?.[key];
+
+                const transformedValue = transform(
+                    localSchema,
+                    valueItem,
+                    err,
+                );
+                return transformedValue;
+            },
+        );
+        if (nonFieldErrors) {
+            errorMap[internal] = nonFieldErrors.join(' ');
+        }
+        return doesObjectHaveNoData(errorMap)
+            ? undefined
+            : errorMap;
+    }
+    return undefined;
+}
+
+export function transformErrorToToggleFormError(formSchema, obj, responseError) {
+    try {
+        return transform(formSchema, obj, responseError);
+    } catch {
+        console.error('Error while transforming server response');
+        return undefined;
+    }
+}

--- a/src/utils/request/deep.ts
+++ b/src/utils/request/deep.ts
@@ -32,9 +32,11 @@ export interface Error {
     reason: string;
     // exception: any;
     value: {
+        // FIXME: deprecate faramErrors as it doesn''t work with new form
         faramErrors: {
             [key: string]: string | undefined;
         },
+        errors: ErrorFromServer['errors'] | undefined,
         messageForNotification: string,
     };
     errorCode: number | undefined;
@@ -175,18 +177,19 @@ export const processDeepError: DeepContextInterface['transformError'] = (
                 faramErrors: {
                     $internal: 'Network error',
                 },
+                errors: undefined,
             },
             errorCode: undefined,
         };
     } else if (res === 'parse') {
         error = {
             reason: 'parse',
-            // exception: e,
             value: {
                 messageForNotification: 'Response parse error',
                 faramErrors: {
                     $internal: 'Response parse error',
                 },
+                errors: undefined,
             },
             errorCode: undefined,
         };
@@ -201,6 +204,7 @@ export const processDeepError: DeepContextInterface['transformError'] = (
         const requestError = {
             faramErrors,
             messageForNotification,
+            errors: res.errors,
         };
 
         error = {


### PR DESCRIPTION
Related to https://github.com/the-deep/client/issues/1826

## Changes

- Fix filter apply action for analysis pillar
- Set server error from analysis pillar update
- Pass response errors to onFailure

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] permission checks
- [x] translations
