### PR TITLE
Add analysis module permissions

### DIFF
--- a/src/constants/viewsAcl.js
+++ b/src/constants/viewsAcl.js
@@ -51,10 +51,15 @@ const notQuestionnaireViewable = ({ isLoggedIn, accessQuestionnaire }) => (
     !isLoggedIn || !accessQuestionnaire
 );
 
-const notAnalysisModuleViewable = ({ isLoggedIn, accessAnalysisModule }) => (
-    !isLoggedIn || !accessAnalysisModule
+const notAnalysisModuleViewable = ({ isLoggedIn, accessAnalysisModule, entryPermissions }) => (
+    !isLoggedIn || !accessAnalysisModule || !entryPermissions.view
 );
 
+const notAnalysisModuleEditable = ({ isLoggedIn, accessAnalysisModule, entryPermissions }) => (
+    !isLoggedIn || !accessAnalysisModule || !(
+        entryPermissions.create || entryPermissions.modify || entryPermissions.delete
+    )
+);
 
 const notQuestionnaireEditable = ({ isLoggedIn, accessQuestionnaire, setupPermissions }) => (
     !isLoggedIn || !setupPermissions.modify || !accessQuestionnaire
@@ -126,7 +131,7 @@ const acl = {
 
     exploreDeep: {},
     analysisModule: { hide: notAnalysisModuleViewable },
-    pillarAnalysis: { hide: notAnalysisModuleViewable },
+    pillarAnalysis: { hide: notAnalysisModuleEditable },
 
     analyticalFramework: { hide: notLoggedIn },
     myProfile: { hide: notLoggedIn },

--- a/src/newViews/AnalysisModule/Analysis/AnalysisPillar/index.tsx
+++ b/src/newViews/AnalysisModule/Analysis/AnalysisPillar/index.tsx
@@ -14,6 +14,7 @@ import {
     List,
 } from '@the-deep/deep-ui';
 import { FiEdit2 } from 'react-icons/fi';
+import Cloak from '#components/general/Cloak';
 import {
     IoTrashOutline,
 } from 'react-icons/io5';
@@ -27,6 +28,19 @@ import { calcPercent } from '#utils/safeCommon';
 
 import _ts from '#ts';
 import styles from './styles.scss';
+
+function shouldHideEdit({
+    hasAnalysisFramework,
+    entryPermissions,
+}: {
+    hasAnalysisFramework: boolean;
+    entryPermissions: {
+        create: boolean;
+        modify: boolean;
+    };
+}) {
+    return (!hasAnalysisFramework || !(entryPermissions.create || entryPermissions.modify));
+}
 
 const statementKeySelector = (d: AnalyticalStatementSummary) => d.id;
 
@@ -106,29 +120,34 @@ function AnalysisPillar(props: Props) {
             )}
             inlineHeadingDescription
             headerActions={(
-                <>
-                    <ButtonLikeLink
-                        to={editLink}
-                        disabled={disabled}
-                        variant="tertiary"
-                        icons={(
-                            <FiEdit2 />
-                        )}
-                    >
-                        {_ts('analysis', 'continueAnalysisButton')}
-                    </ButtonLikeLink>
-                    <QuickActionConfirmButton
-                        name={pillarId}
-                        onConfirm={onDeleteConfirmClick}
-                        title={_ts('analysis', 'deletePillarButtonTitle')}
-                        message={_ts('analysis', 'deletePillarConfirmMessage')}
-                        disabled={disabled}
-                        showConfirmationInitially={false}
-                        variant="secondary"
-                    >
-                        <IoTrashOutline />
-                    </QuickActionConfirmButton>
-                </>
+                <Cloak
+                    hide={shouldHideEdit}
+                    render={(
+                        <>
+                            <ButtonLikeLink
+                                to={editLink}
+                                disabled={disabled}
+                                variant="tertiary"
+                                icons={(
+                                    <FiEdit2 />
+                                )}
+                            >
+                                {_ts('analysis', 'continueAnalysisButton')}
+                            </ButtonLikeLink>
+                            <QuickActionConfirmButton
+                                name={pillarId}
+                                onConfirm={onDeleteConfirmClick}
+                                title={_ts('analysis', 'deletePillarButtonTitle')}
+                                message={_ts('analysis', 'deletePillarConfirmMessage')}
+                                disabled={disabled}
+                                showConfirmationInitially={false}
+                                variant="secondary"
+                            >
+                                <IoTrashOutline />
+                            </QuickActionConfirmButton>
+                        </>
+                    )}
+                />
             )}
             headerDescription={(
                 <TextOutput

--- a/src/newViews/AnalysisModule/Analysis/index.tsx
+++ b/src/newViews/AnalysisModule/Analysis/index.tsx
@@ -29,6 +29,7 @@ import {
 } from 'recharts';
 
 import ProgressLine from '#newComponents/viz/ProgressLine';
+import Cloak from '#components/general/Cloak';
 import {
     useModalState,
 } from '#hooks/stateManagement';
@@ -75,6 +76,20 @@ const barChartMargin = {
 };
 const BAR_TICK_COUNT = 5;
 const MAX_BAR_SIZE = 16;
+
+function shouldHideEdit({
+    hasAnalysisFramework,
+    entryPermissions,
+}: {
+    hasAnalysisFramework: boolean;
+    entryPermissions: {
+        create: boolean;
+        modify: boolean;
+    };
+}) {
+    return (!hasAnalysisFramework || !(entryPermissions.create || entryPermissions.modify));
+}
+
 
 interface ComponentProps {
     analysisId: number;
@@ -175,39 +190,44 @@ function Analysis(props: ComponentProps) {
                 />
             )}
             headerActions={(
-                <>
-                    <Button
-                        name={analysisId}
-                        onClick={onEdit}
-                        disabled={disabled}
-                        variant="tertiary"
-                        icons={(
-                            <FiEdit2 />
-                        )}
-                    >
-                        {_ts('analysis', 'editAnalysisTitle')}
-                    </Button>
-                    <QuickActionButton
-                        name="clone"
-                        onClick={setModalVisible}
-                        disabled={disabled}
-                        title={_ts('analysis', 'cloneAnalysisButtonTitle')}
-                        variant="secondary"
-                    >
-                        <IoCopyOutline />
-                    </QuickActionButton>
-                    <QuickActionConfirmButton
-                        name="delete"
-                        onConfirm={handleDeleteAnalysis}
-                        disabled={disabled}
-                        title={_ts('analysis', 'deleteAnalysisButtonTitle')}
-                        message={_ts('analysis', 'deleteAnalysisConfirmMessage')}
-                        variant="secondary"
-                        showConfirmationInitially={false}
-                    >
-                        <IoTrashOutline />
-                    </QuickActionConfirmButton>
-                </>
+                <Cloak
+                    hide={shouldHideEdit}
+                    render={(
+                        <>
+                            <Button
+                                name={analysisId}
+                                onClick={onEdit}
+                                disabled={disabled}
+                                variant="tertiary"
+                                icons={(
+                                    <FiEdit2 />
+                                )}
+                            >
+                                {_ts('analysis', 'editAnalysisTitle')}
+                            </Button>
+                            <QuickActionButton
+                                name="clone"
+                                onClick={setModalVisible}
+                                disabled={disabled}
+                                title={_ts('analysis', 'cloneAnalysisButtonTitle')}
+                                variant="secondary"
+                            >
+                                <IoCopyOutline />
+                            </QuickActionButton>
+                            <QuickActionConfirmButton
+                                name="delete"
+                                onConfirm={handleDeleteAnalysis}
+                                disabled={disabled}
+                                title={_ts('analysis', 'deleteAnalysisButtonTitle')}
+                                message={_ts('analysis', 'deleteAnalysisConfirmMessage')}
+                                variant="secondary"
+                                showConfirmationInitially={false}
+                            >
+                                <IoTrashOutline />
+                            </QuickActionConfirmButton>
+                        </>
+                    )}
+                />
             )}
             horizontallyCompactContent
             contentClassName={styles.content}

--- a/src/newViews/AnalysisModule/index.tsx
+++ b/src/newViews/AnalysisModule/index.tsx
@@ -39,6 +39,7 @@ import { useRequest, useLazyRequest } from '#utils/request';
 import RechartsLegend from '#newComponents/ui/RechartsLegend';
 import { SubNavbar } from '#components/general/Navbar';
 import { getDateWithTimezone } from '#utils/common';
+import Cloak from '#components/general/Cloak';
 import {
     shortMonthNamesMap,
     calcPercent,
@@ -115,6 +116,18 @@ const timelineTickSelector = (d: number) => {
 
     return `${year}-${shortMonthNamesMap[month]}`;
 };
+function shouldHideEdit({
+    hasAnalysisFramework,
+    entryPermissions,
+}: {
+    hasAnalysisFramework: boolean;
+    entryPermissions: {
+        create: boolean;
+        modify: boolean;
+    };
+}) {
+    return (!hasAnalysisFramework || !(entryPermissions.create || entryPermissions.modify));
+}
 
 interface AnalysisOverview {
     analysisList: AnalysisList[];
@@ -249,18 +262,23 @@ function AnalysisModule(props: AnalysisModuleProps) {
     return (
         <div className={_cs(styles.analysisModule, className)}>
             <SubNavbar>
-                <div className={styles.subNavbar}>
-                    <Button
-                        name={undefined}
-                        variant="primary"
-                        onClick={handleNewAnalysisCreateClick}
-                        icons={(
-                            <IoAdd />
-                        )}
-                    >
-                        {_ts('analysis', 'setupNewAnalysisButtonLabel')}
-                    </Button>
-                </div>
+                <Cloak
+                    hide={shouldHideEdit}
+                    render={(
+                        <div className={styles.subNavbar}>
+                            <Button
+                                name={undefined}
+                                variant="primary"
+                                onClick={handleNewAnalysisCreateClick}
+                                icons={(
+                                    <IoAdd />
+                                )}
+                            >
+                                {_ts('analysis', 'setupNewAnalysisButtonLabel')}
+                            </Button>
+                        </div>
+                    )}
+                />
             </SubNavbar>
             <Container
                 className={styles.summary}


### PR DESCRIPTION
Fixes https://zube.io/deep/deep/c/3779

## Changes

* Add permissions in the analysis module
    * Users who cannot edit entries should not be able to view edit buttons or edit page

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations