### PR TITLE
Show add assessment button only if lead is of type assessment

### DIFF
--- a/app/types/lead.tsx
+++ b/app/types/lead.tsx
@@ -53,6 +53,7 @@ export interface Lead extends DatabaseEntityBase {
     pageCount: number;
     wordCount?: number;
     confidentialityDisplay?: string;
+    isAssessmentLead?: boolean;
 
     attachment?: {
         id: number;

--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -306,6 +306,7 @@ function SourcesTable(props: Props) {
                 onDeleteClick: handleDelete,
                 entriesCount: data.entriesCount,
                 projectId,
+                isAssessmentLead: data.isAssessmentLead,
             }),
             columnWidth: 196,
         };


### PR DESCRIPTION
- fixes https://github.com/the-deep/server/issues/831
- Depends on https://github.com/the-deep/server/pull/865

## Changes

* Show add assessment lead button only if isAssessmentLead boolean is true

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations
