### PR TITLE
Fix styling in widget forms in secondary tagging

### DIFF
--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateRangeWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateRangeWidgetForm/index.tsx
@@ -88,6 +88,7 @@ function DateRangeWidgetForm(props: DateRangeWidgetFormProps) {
             onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
+                className={styles.container}
                 heading={value.title ?? 'Unnamed'}
                 headerActions={(
                     <>

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateRangeWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateRangeWidgetForm/styles.css
@@ -1,4 +1,7 @@
 .date-range-widget-form {
+    .container {
+        background-color: var(--dui-color-foreground);
+    }
     .error,
     .input {
         margin: var(--dui-spacing-small) var(--dui-spacing-medium);

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateWidgetForm/index.tsx
@@ -148,6 +148,7 @@ function DateWidgetForm(props: DateWidgetFormProps) {
             onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
+                className={styles.container}
                 heading={value.title ?? 'Unnamed'}
                 headerActions={(
                     <>

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/DateWidgetForm/styles.css
@@ -1,4 +1,7 @@
 .date-widget-form {
+    .container {
+        background-color: var(--dui-color-foreground);
+    }
     .error,
     .input {
         margin: var(--dui-spacing-small) var(--dui-spacing-medium);

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/MultiSelectWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/MultiSelectWidgetForm/index.tsx
@@ -253,6 +253,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 clientId,
                 order: oldOptions.length,
             };
+            setExpandedOptionId(newOption.clientId);
             onFieldChange(
                 [...reorder(oldOptions), newOption],
                 'options' as const,

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/NumberWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/NumberWidgetForm/index.tsx
@@ -187,6 +187,7 @@ function NumberWidgetForm(props: NumberWidgetFormProps) {
             onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
+                className={styles.container}
                 heading={value.title ?? 'Unnamed'}
                 headerActions={(
                     <>

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/NumberWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/NumberWidgetForm/styles.css
@@ -1,4 +1,7 @@
 .number-widget-form {
+    .container {
+        background-color: var(--dui-color-foreground);
+    }
     .error,
     .input {
         margin: var(--dui-spacing-small) var(--dui-spacing-medium);

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/OrganigramWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/OrganigramWidgetForm/styles.css
@@ -2,8 +2,31 @@
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    gap: var(--dui-spacing-medium);
 
     .container {
+        display: flex;
+        flex-direction: column;
         background-color: var(--dui-color-foreground);
+        overflow-y: auto;
+        gap: var(--dui-spacing-medium);
+    }
+
+    .list-container {
+        background-color: var(--dui-background);
+    }
+
+    .sortable-list{
+        display: flex;
+        flex-direction: column;
+        margin-top: var(--dui-spacing-medium);
+        border-left: var(--dui-width-separator-medium) dotted var(--dui-color-separator);
+        padding-left: var(--dui-spacing-medium);
+        gap: var(--dui-spacing-medium);
+    }
+
+    .option-input {
+        margin: var(--dui-spacing-small) 0;
     }
 }
+

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/ScaleWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/ScaleWidgetForm/index.tsx
@@ -8,6 +8,7 @@ import {
     Button,
     Checkbox,
     SelectInput,
+    ColorInput,
     TextInput,
     QuickActionButton,
     ControlledExpandableContainer,
@@ -215,6 +216,13 @@ function OptionInput(props: OptionInputProps) {
             )}
         >
             <NonFieldError error={error} />
+            <ColorInput
+                // FIXME: use translation
+                name="color"
+                value={value.color ?? '#414141'}
+                onChange={onFieldChange}
+                className={styles.optionInput}
+            />
             <TextInput
                 // FIXME: use translation
                 label="Label"
@@ -223,15 +231,6 @@ function OptionInput(props: OptionInputProps) {
                 onChange={onFieldChange}
                 error={error?.label}
                 autoFocus={autoFocus}
-                className={styles.optionInput}
-            />
-            <TextInput
-                // FIXME: use translation
-                label="Color"
-                name="color"
-                value={value.color}
-                onChange={onFieldChange}
-                error={error?.color}
                 className={styles.optionInput}
             />
         </ControlledExpandableContainer>
@@ -297,6 +296,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 clientId,
                 order: oldOptions.length,
             };
+            setExpandedScaleId(newOption.clientId);
             onFieldChange(
                 [...reorder(oldOptions), newOption],
                 'options' as const,

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/SingleSelectWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/SingleSelectWidgetForm/index.tsx
@@ -254,6 +254,7 @@ function DataInput<K extends string>(props: DataInputProps<K>) {
                 clientId,
                 order: oldOptions.length,
             };
+            setExpandedOptionId(newOption.clientId);
             onFieldChange(
                 [...reorder(oldOptions), newOption],
                 'options' as const,

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TextWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TextWidgetForm/index.tsx
@@ -145,6 +145,7 @@ function TextWidgetForm(props: TextWidgetFormProps) {
             onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
+                className={styles.container}
                 heading={value.title ?? 'Unnamed'}
                 headerActions={(
                     <>

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TextWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TextWidgetForm/styles.css
@@ -1,4 +1,7 @@
 .text-widget-form {
+    .container {
+        background-color: var(--dui-color-foreground);
+    }
     .input {
         margin: var(--dui-spacing-small) var(--dui-spacing-medium);
     }

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeRangeWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeRangeWidgetForm/index.tsx
@@ -90,6 +90,7 @@ function TimeRangeWidgetForm(props: TimeRangeWidgetFormProps) {
             onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
+                className={styles.container}
                 heading={value.title ?? 'Unnamed'}
                 headerActions={(
                     <>

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeRangeWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeRangeWidgetForm/styles.css
@@ -1,4 +1,7 @@
 .time-range-widget-form {
+    .container {
+        background-color: var(--dui-color-foreground);
+    }
     .error,
     .input {
         margin: var(--dui-spacing-small) var(--dui-spacing-medium);

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeWidgetForm/index.tsx
@@ -148,6 +148,7 @@ function TimeWidgetForm(props: TimeWidgetFormProps) {
             onSubmit={createSubmitHandler(validate, setError, handleSubmit)}
         >
             <Container
+                className={styles.container}
                 heading={value.title ?? 'Unnamed'}
                 headerActions={(
                     <>

--- a/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeWidgetForm/styles.css
+++ b/app/views/AnalyticalFramework/FrameworkForm/components/WidgetEditor/TimeWidgetForm/styles.css
@@ -1,4 +1,7 @@
 .time-widget-form {
+    .container {
+        background-color: var(--dui-color-foreground);
+    }
     .error,
     .input {
         margin: var(--dui-spacing-small) var(--dui-spacing-medium);


### PR DESCRIPTION
## Changes

* Make controlled expandable container in Organigram Widget Form
* Fix styling in widget forms

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

