### PR TITLE
Fix Recent Activity page

### DIFF
--- a/app/views/Home/Assignment/AssignmentItem/index.tsx
+++ b/app/views/Home/Assignment/AssignmentItem/index.tsx
@@ -27,6 +27,7 @@ function AssignmentItem(props: AssignmentItemProps) {
         markAsDonePending,
         createdByDetails,
         contentObjectDetails,
+        contentObjectType,
         projectDetails,
         createdAt,
     } = props;
@@ -56,6 +57,10 @@ function AssignmentItem(props: AssignmentItemProps) {
                 {createdByDetails.displayName}
                 &nbsp;
                 {_ts('assignment', 'assignedYou')}
+                &nbsp;
+                a
+                &nbsp;
+                {contentObjectType}
                 &nbsp;
                 <Link
                     to={generatePath(routes.entryEdit.path, {

--- a/app/views/Home/RecentActivity/ActivityItem/index.tsx
+++ b/app/views/Home/RecentActivity/ActivityItem/index.tsx
@@ -6,8 +6,6 @@ import {
 
 import Avatar from '#components/Avatar';
 
-import _ts from '#ts';
-
 import styles from './styles.css';
 
 interface RecentActivityProps {
@@ -16,6 +14,66 @@ interface RecentActivityProps {
     createdByDisplayName: string;
     createdByDisplayPicture?: string;
     type: string;
+}
+
+interface messageProps {
+    createdByDisplayName: string;
+    projectDisplayName: string;
+    type: string;
+}
+
+function ActionMessage(props: messageProps) {
+    const {
+        createdByDisplayName,
+        projectDisplayName,
+        type,
+    } = props;
+    if (type === 'lead') {
+        return (
+            <>
+                <span className={styles.boldText}>
+                    {createdByDisplayName}
+                </span>
+                &nbsp;
+                added a source on
+                &nbsp;
+                <span className={styles.boldText}>
+                    {projectDisplayName}
+                </span>
+            </>
+        );
+    }
+    if (type === 'entry') {
+        return (
+            <>
+                <span className={styles.boldText}>
+                    {createdByDisplayName}
+                </span>
+                &nbsp;
+                added an entry on
+                &nbsp;
+                <span className={styles.boldText}>
+                    {projectDisplayName}
+                </span>
+            </>
+        );
+    }
+    if (type === 'entry-comment') {
+        return (
+            <div className={styles.description}>
+                <span className={styles.boldText}>
+                    {createdByDisplayName}
+                </span>
+                &nbsp;
+                added a comment on an entry on
+                &nbsp;
+                <span className={styles.boldText}>
+                    {projectDisplayName}
+                </span>
+            </div>
+        );
+    }
+    return null;
 }
 
 function ActivityItem(props: RecentActivityProps) {
@@ -33,25 +91,17 @@ function ActivityItem(props: RecentActivityProps) {
             icons={(
                 <Avatar
                     className={styles.displayPicture}
-                    src={createdByDisplayPicture}
+                    src={createdByDisplayPicture ?? undefined}
+                    name={createdByDisplayName}
                 />
             )}
             childrenContainerClassName={styles.mainContent}
         >
-            <div className={styles.description}>
-                <span className={styles.boldText}>
-                    {createdByDisplayName}
-                </span>
-                &nbsp;
-                {(type === 'lead'
-                    ? _ts('recentActivity', 'leadAdded')
-                    : 'added an entry on'
-                )}
-                &nbsp;
-                <span className={styles.boldText}>
-                    {projectDisplayName}
-                </span>
-            </div>
+            <ActionMessage
+                createdByDisplayName={createdByDisplayName}
+                projectDisplayName={projectDisplayName}
+                type={type}
+            />
             <DateOutput
                 className={styles.createdDate}
                 value={createdAt}

--- a/app/views/Home/RecentActivity/ActivityItem/index.tsx
+++ b/app/views/Home/RecentActivity/ActivityItem/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@the-deep/deep-ui';
 
 import Avatar from '#components/Avatar';
+import generateString from '#utils/string';
 
 import styles from './styles.css';
 
@@ -14,66 +15,6 @@ interface RecentActivityProps {
     createdByDisplayName: string;
     createdByDisplayPicture?: string;
     type: string;
-}
-
-interface messageProps {
-    createdByDisplayName: string;
-    projectDisplayName: string;
-    type: string;
-}
-
-function ActionMessage(props: messageProps) {
-    const {
-        createdByDisplayName,
-        projectDisplayName,
-        type,
-    } = props;
-    if (type === 'lead') {
-        return (
-            <>
-                <span className={styles.boldText}>
-                    {createdByDisplayName}
-                </span>
-                &nbsp;
-                added a source on
-                &nbsp;
-                <span className={styles.boldText}>
-                    {projectDisplayName}
-                </span>
-            </>
-        );
-    }
-    if (type === 'entry') {
-        return (
-            <>
-                <span className={styles.boldText}>
-                    {createdByDisplayName}
-                </span>
-                &nbsp;
-                added an entry on
-                &nbsp;
-                <span className={styles.boldText}>
-                    {projectDisplayName}
-                </span>
-            </>
-        );
-    }
-    if (type === 'entry-comment') {
-        return (
-            <div className={styles.description}>
-                <span className={styles.boldText}>
-                    {createdByDisplayName}
-                </span>
-                &nbsp;
-                added a comment on an entry on
-                &nbsp;
-                <span className={styles.boldText}>
-                    {projectDisplayName}
-                </span>
-            </div>
-        );
-    }
-    return null;
 }
 
 function ActivityItem(props: RecentActivityProps) {
@@ -97,11 +38,25 @@ function ActivityItem(props: RecentActivityProps) {
             )}
             childrenContainerClassName={styles.mainContent}
         >
-            <ActionMessage
-                createdByDisplayName={createdByDisplayName}
-                projectDisplayName={projectDisplayName}
-                type={type}
-            />
+            <div className={styles.description}>
+                {generateString(
+                    '{createdByDisplayName} added {article} {type} on {projectDisplayName}',
+                    {
+                        createdByDisplayName: (
+                            <span className={styles.boldText}>
+                                {createdByDisplayName}
+                            </span>
+                        ),
+                        article: (type === 'lead' ? 'a' : 'an'),
+                        type,
+                        projectDisplayName: (
+                            <span className={styles.boldText}>
+                                {projectDisplayName}
+                            </span>
+                        ),
+                    },
+                )}
+            </div>
             <DateOutput
                 className={styles.createdDate}
                 value={createdAt}

--- a/app/views/Home/RecentActivity/index.tsx
+++ b/app/views/Home/RecentActivity/index.tsx
@@ -27,7 +27,6 @@ function RecentActivities() {
 
     const activityRendererParams = useCallback((_: string, info: RecentActivityItem) => ({
         activityId: keySelector(info),
-        activity: info,
         projectDisplayName: info.projectDisplayName,
         createdAt: info.createdAt,
         createdByDisplayName: info.createdByDisplayName,

--- a/app/views/Home/RecentActivity/index.tsx
+++ b/app/views/Home/RecentActivity/index.tsx
@@ -27,6 +27,7 @@ function RecentActivities() {
 
     const activityRendererParams = useCallback((_: string, info: RecentActivityItem) => ({
         activityId: keySelector(info),
+        activity: info,
         projectDisplayName: info.projectDisplayName,
         createdAt: info.createdAt,
         createdByDisplayName: info.createdByDisplayName,

--- a/app/views/Project/EntryEdit/index.tsx
+++ b/app/views/Project/EntryEdit/index.tsx
@@ -308,12 +308,12 @@ function EntryEdit(props: Props) {
 
                 if (!ok) {
                     alert.show(
-                        'Failed to change lead status!',
+                        'Failed to change source status!',
                         { variant: 'error' },
                     );
                 } else {
                     alert.show(
-                        'Successfully marked lead as tagged!',
+                        'Successfully marked source as tagged!',
                         { variant: 'success' },
                     );
                 }
@@ -329,7 +329,7 @@ function EntryEdit(props: Props) {
             },
             onError: () => {
                 alert.show(
-                    'Failed to change lead status!',
+                    'Failed to change source status!',
                     { variant: 'error' },
                 );
             },
@@ -514,7 +514,7 @@ function EntryEdit(props: Props) {
                     } else {
                         handleLeadSave(false);
                         alert.show(
-                            'Lead cannot be finalized due to some errors in entries.',
+                            'Source cannot be finalized due to some errors in entries.',
                             { variant: 'error' },
                         );
                     }
@@ -618,6 +618,7 @@ function EntryEdit(props: Props) {
                             },
                         });
                     } else {
+                        handleLeadSave(shouldSetFinalize);
                         alert.show(
                             'Entries updated successfully!',
                             { variant: 'success' },
@@ -628,6 +629,7 @@ function EntryEdit(props: Props) {
             submit();
         },
         [
+            handleLeadSave,
             setFormError,
             formValidate,
             bulkUpdateEntries,
@@ -639,8 +641,14 @@ function EntryEdit(props: Props) {
     );
 
     const handleSaveClick = useCallback(
-        () => handleSubmit(false),
-        [handleSubmit],
+        () => {
+            if (!entriesFormStale) {
+                handleLeadSave(false);
+            } else {
+                handleSubmit(false);
+            }
+        },
+        [handleSubmit, handleLeadSave, entriesFormStale],
     );
 
     const handleFinalizeClick = useCallback(

--- a/app/views/Project/EntryEdit/index.tsx
+++ b/app/views/Project/EntryEdit/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@togglecorp/fujs';
 import {
     PendingMessage,
+    ConfirmButton,
     Button,
     Tabs,
     Tab,
@@ -1111,14 +1112,16 @@ function EntryEdit(props: Props) {
                             >
                                 Save
                             </Button>
-                            <Button
+                            <ConfirmButton
                                 name={undefined}
                                 disabled={disableFinalizeButton}
                                 variant="primary"
-                                onClick={handleFinalizeClick}
+                                onConfirm={handleFinalizeClick}
+                                message="Finalizing the source will mark it as tagged.
+                                Are you sure you want to finalize the source and all its entries?"
                             >
                                 Finalize
-                            </Button>
+                            </ConfirmButton>
                         </>
                     )}
                 >

--- a/app/views/Project/Tagging/Export/LeadsSelection/index.tsx
+++ b/app/views/Project/Tagging/Export/LeadsSelection/index.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useState, useMemo } from 'react';
-import { _cs, isNotDefined } from '@togglecorp/fujs';
+import {
+    _cs,
+    isNotDefined,
+    isDefined,
+} from '@togglecorp/fujs';
 import {
     DateOutput,
     Pager,
@@ -285,7 +289,7 @@ function LeadsSelection(props: Props) {
             createStringColumn<Lead, string>(
                 'source',
                 'Publisher',
-                (item) => item.source && organizationTitleSelector(item.source),
+                (item) => (item.source ? organizationTitleSelector(item.source) : undefined),
                 {
                     sortable: true,
                     columnWidth: 160,
@@ -294,7 +298,7 @@ function LeadsSelection(props: Props) {
             createStringColumn<Lead, string>(
                 'authors',
                 'Authors',
-                (item) => item?.authors?.map((v) => organizationTitleSelector(v)).join(','),
+                (item) => item?.authors?.map((v) => organizationTitleSelector(v)).filter(isDefined).join(','),
                 {
                     sortable: false,
                     columnWidth: 144,

--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -13,7 +13,6 @@ import {
     DateOutputProps,
     Kraken,
     Link,
-    LinkProps,
     Pager,
     SortContext,
     TableView,
@@ -63,6 +62,7 @@ import Actions, { Props as ActionsProps } from './Actions';
 import LeadEditModal from '../LeadEditModal';
 import BulkActions from './BulkActions';
 import EntryList from './EntryList';
+
 import styles from './styles.css';
 
 function sourcesKeySelector(d: Lead) {
@@ -186,6 +186,32 @@ export const PROJECT_SOURCES = gql`
         }
     }
 `;
+
+interface SourceLinkProps {
+    title?: string;
+    link?: string;
+}
+
+function SourceLink(props: SourceLinkProps) {
+    const {
+        link,
+        title,
+    } = props;
+
+    if (!link) {
+        return (
+            <div>{title}</div>
+        );
+    }
+
+    return (
+        <Link
+            to={link}
+        >
+            {title}
+        </Link>
+    );
+}
 
 const DELETE_LEAD = gql`
     mutation DeleteLead(
@@ -473,7 +499,7 @@ function SourcesTable(props: Props) {
             columnWidth: 144,
         };
         const publisherColumn: TableColumn<
-            Lead, string, LinkProps, TableHeaderCellProps
+            Lead, string, SourceLinkProps, TableHeaderCellProps
         > = {
             id: 'source',
             title: _ts('sourcesTable', 'publisher'),
@@ -481,12 +507,10 @@ function SourcesTable(props: Props) {
             headerCellRendererParams: {
                 sortable: true,
             },
-            cellRenderer: Link,
-            cellRendererClassName: styles.link,
+            cellRenderer: SourceLink,
             cellRendererParams: (_, data) => ({
-                linkElementClassName: _cs(!data.source?.url && styles.emptyLink),
-                children: data.source?.title,
-                to: data.source?.url ?? '#',
+                title: data.source ? organizationTitleSelector(data.source) : undefined,
+                link: data.source?.url,
             }),
             columnWidth: 160,
         };

--- a/app/views/Project/Tagging/Sources/SourcesTable/styles.css
+++ b/app/views/Project/Tagging/Sources/SourcesTable/styles.css
@@ -23,15 +23,6 @@
                 background-color: var(--dui-color-foreground);
             }
 
-            .link {
-                cursor: ;
-                pointer-events: none;
-
-                .empty-link {
-                    color: var(--dui-color-text);
-                }
-            }
-
             .expanded-row {
                 .expanded-cell {
                     border-bottom: 0;


### PR DESCRIPTION
- Addresses #4329 and #4357
- Depends on https://github.com/the-deep/server/pull/1014

## Changes
* Add 'entry-comment' type in recent activity messages
* Handle when no display picture in Recent Activity

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers