### PR TITLE
Add public options for organizations and analysis framework for public

### DIFF
--- a/app/components/selections/PublicFrameworkMultiSelectInput/index.tsx
+++ b/app/components/selections/PublicFrameworkMultiSelectInput/index.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useMemo } from 'react';
+
+import {
+    SearchMultiSelectInput,
+    SearchMultiSelectInputProps,
+} from '@the-deep/deep-ui';
+import { useQuery, gql } from '@apollo/client';
+
+import {
+    PublicAnalysisFrameworkOptionsQuery,
+    PublicAnalysisFrameworkOptionsQueryVariables,
+} from '#generated/types';
+import useDebouncedValue from '#hooks/useDebouncedValue';
+
+const PUBLIC_ANALYSIS_FRAMEWORKS = gql`
+    query PublicAnalysisFrameworkOptions($search: String) {
+        publicAnalysisFrameworks(search: $search) {
+            totalCount
+            results {
+                id
+                title
+            }
+        }
+    }
+`;
+
+export type AnalysisFramework = NonNullable<NonNullable<NonNullable<PublicAnalysisFrameworkOptionsQuery['publicAnalysisFrameworks']>['results']>[number]>;
+
+type Def = { containerClassName?: string };
+type PublicAnalysisFrameworkMultiSelectInputProps<K extends string> = SearchMultiSelectInputProps<
+    string,
+    K,
+    AnalysisFramework,
+    Def,
+    'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount' | 'onShowDropdownChange'
+>;
+
+const keySelector = (d: AnalysisFramework) => d.id;
+const labelSelector = (d: AnalysisFramework) => d.title;
+
+function PublicAnalysisFrameworkSearchMultiSelectInput<K extends string>(
+    props: PublicAnalysisFrameworkMultiSelectInputProps<K>,
+) {
+    const {
+        className,
+        ...otherProps
+    } = props;
+
+    const [opened, setOpened] = useState(false);
+    const [searchText, setSearchText] = useState<string>('');
+    const debouncedSearchText = useDebouncedValue(searchText);
+
+    const variables = useMemo(() => ({
+        search: debouncedSearchText,
+    }), [debouncedSearchText]);
+
+    const {
+        data,
+        loading,
+    } = useQuery<PublicAnalysisFrameworkOptionsQuery, PublicAnalysisFrameworkOptionsQueryVariables>(
+        PUBLIC_ANALYSIS_FRAMEWORKS,
+        {
+            variables,
+            skip: !opened,
+        },
+    );
+
+    return (
+        <SearchMultiSelectInput
+            {...otherProps}
+            className={className}
+            keySelector={keySelector}
+            labelSelector={labelSelector}
+            onSearchValueChange={setSearchText}
+            searchOptions={data?.publicAnalysisFrameworks?.results}
+            optionsPending={loading}
+            totalOptionsCount={data?.publicAnalysisFrameworks?.totalCount ?? undefined}
+            onShowDropdownChange={setOpened}
+        />
+    );
+}
+
+export default PublicAnalysisFrameworkSearchMultiSelectInput;

--- a/app/components/selections/PublicOrganizationMultiSelectInput/index.tsx
+++ b/app/components/selections/PublicOrganizationMultiSelectInput/index.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useMemo } from 'react';
+import { SearchMultiSelectInput, SearchMultiSelectInputProps } from '@the-deep/deep-ui';
+import { useQuery, gql } from '@apollo/client';
+import {
+    PublicOrganizationOptionsQuery,
+    PublicOrganizationOptionsQueryVariables,
+} from '#generated/types';
+
+import useDebouncedValue from '#hooks/useDebouncedValue';
+
+const PUBLIC_ORGANIZATIONS = gql`
+    query PublicOrganizationOptions($search: String) {
+        publicOrganizations(search: $search) {
+            results {
+                id
+                title
+            }
+            totalCount
+        }
+    }
+`;
+
+export type BasicOrganization = NonNullable<NonNullable<NonNullable<PublicOrganizationOptionsQuery['publicOrganizations']>['results']>[number]>;
+
+type Def = { containerClassName?: string };
+type PublicOrganizationMultiSelectInputProps<K extends string> = SearchMultiSelectInputProps<
+    string,
+    K,
+    BasicOrganization,
+    Def,
+    'onSearchValueChange' | 'searchOptions' | 'optionsPending' | 'keySelector' | 'labelSelector' | 'totalOptionsCount' | 'onShowDropdownChange'
+>;
+
+const keySelector = (d: BasicOrganization) => d.id;
+const labelSelector = (d: BasicOrganization) => d.title;
+
+function PublicOrganizationMultiSelectInput<K extends string>(
+    props: PublicOrganizationMultiSelectInputProps<K>,
+) {
+    const {
+        className,
+        ...otherProps
+    } = props;
+
+    const [opened, setOpened] = useState(false);
+    const [searchText, setSearchText] = useState<string>('');
+    const debouncedSearchText = useDebouncedValue(searchText);
+
+    const variables = useMemo(() => ({
+        search: debouncedSearchText,
+    }), [debouncedSearchText]);
+
+    const { data, loading } = useQuery<
+        PublicOrganizationOptionsQuery,
+        PublicOrganizationOptionsQueryVariables
+    >(
+        PUBLIC_ORGANIZATIONS,
+        {
+            variables,
+            skip: !opened,
+        },
+    );
+
+    return (
+        <SearchMultiSelectInput
+            {...otherProps}
+            className={className}
+            keySelector={keySelector}
+            labelSelector={labelSelector}
+            onSearchValueChange={setSearchText}
+            searchOptions={data?.publicOrganizations?.results}
+            optionsPending={loading}
+            totalOptionsCount={data?.publicOrganizations?.totalCount ?? undefined}
+            onShowDropdownChange={setOpened}
+        />
+    );
+}
+
+export default PublicOrganizationMultiSelectInput;

--- a/app/views/ExploreDeep/ProjectFilterForm/index.tsx
+++ b/app/views/ExploreDeep/ProjectFilterForm/index.tsx
@@ -14,13 +14,13 @@ import {
     useForm,
 } from '@togglecorp/toggle-form';
 
-import OrganizationMultiSelectInput, {
+import PublicOrganizationMultiSelectInput, {
     BasicOrganization,
-} from '#components/selections/NewOrganizationMultiSelectInput';
+} from '#components/selections/PublicOrganizationMultiSelectInput';
 
-import FrameworkMultiSelectInput, {
+import PublicFrameworkMultiSelectInput, {
     AnalysisFramework,
-} from '#components/selections/FrameworkMultiSelectInput';
+} from '#components/selections/PublicFrameworkMultiSelectInput';
 import {
     ProjectListQueryVariables,
 } from '#generated/types';
@@ -112,7 +112,7 @@ function ProjectFilterForm(props: Props) {
                 value={value?.endDate}
                 onChange={setFieldValue}
             />
-            <OrganizationMultiSelectInput
+            <PublicOrganizationMultiSelectInput
                 name="organizations"
                 label="Organizations"
                 value={value?.organizations}
@@ -121,7 +121,7 @@ function ProjectFilterForm(props: Props) {
                 onOptionsChange={setOrganizationOptions}
                 placeholder="any"
             />
-            <FrameworkMultiSelectInput
+            <PublicFrameworkMultiSelectInput
                 name="analysisFrameworks"
                 label="Analysis Frameworks"
                 placeholder="any"


### PR DESCRIPTION
- Depends on https://github.com/the-deep/server/pull/1043

## Changes
* Add public options for organizations and analysis framework for public explore page
* Add PublicOrganizationsMultiSelectInput
* Add PublicFrameworkMultiSelectInput


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [ ] translations
