### PR TITLE
Use old extension for screenshot

### DIFF
--- a/app/Base/configs/env.ts
+++ b/app/Base/configs/env.ts
@@ -18,6 +18,8 @@ export const aryVizEndpoint = process.env.REACT_APP_ASSESSMENT_VIZ_URL || 'https
 export const entriesVizEndpoint = process.env.REACT_APP_ENTRY_VIZ_URL || 'https://the-deep.github.io/deepviz-entries/';
 
 // Chrome extension
+export const oldExtensionId = process.env.REACT_APP_OLD_BROWSER_EXTENSION_ID || 'kafonkgglonkbldmcigbdojiadfcmcdc';
+export const oldExtensionChromeUrl = `https://chrome.google.com/webstore/detail/deep-2-add-lead/${oldExtensionId}`;
 export const extensionId = process.env.REACT_APP_BROWSER_EXTENSION_ID || 'hkmakfhfikfhllpkfpkkaoonapclfajf';
 export const extensionChromeUrl = `https://chrome.google.com/webstore/detail/deep/${extensionId}`;
 

--- a/app/components/Screenshot/index.tsx
+++ b/app/components/Screenshot/index.tsx
@@ -4,7 +4,7 @@ import { brush as d3Brush } from 'd3-brush';
 import { select } from 'd3-selection';
 import { _cs } from '@togglecorp/fujs';
 
-import { extensionChromeUrl } from '#base/configs/env';
+import { oldExtensionChromeUrl } from '#base/configs/env';
 
 import { getScreenshot } from '#utils/browserExtension';
 
@@ -151,7 +151,7 @@ function Screenshot(props: Props) {
                     <a
                         className={styles.link}
                         // NOTE: the `deep` username is hardcoded here
-                        href={extensionChromeUrl}
+                        href={oldExtensionChromeUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                     >

--- a/app/utils/browserExtension.tsx
+++ b/app/utils/browserExtension.tsx
@@ -1,7 +1,12 @@
 import { extensionId } from '#base/configs/env';
 
+// FIXME: Use new extension keys for the following after extension is deployed
+const EXTENSION_GET_SCREENSHOT = 'get-screenshot';
+const EXTENSION_SET_TOKEN = 'set-token';
+/*
 const EXTENSION_GET_SCREENSHOT = 'deep_extension_le_get-screenshot';
 const EXTENSION_SET_TOKEN = 'deep_extension_le_set-token';
+*/
 
 interface ScreenshotResponse {
     image: string;

--- a/app/utils/browserExtension.tsx
+++ b/app/utils/browserExtension.tsx
@@ -1,4 +1,4 @@
-import { extensionId } from '#base/configs/env';
+import { oldExtensionId } from '#base/configs/env';
 
 // FIXME: Use new extension keys for the following after extension is deployed
 const EXTENSION_GET_SCREENSHOT = 'get-screenshot';
@@ -22,7 +22,7 @@ export const getScreenshot = () => {
             reject();
         }
 
-        chrome.runtime.sendMessage(extensionId, data, (response: ScreenshotResponse) => {
+        chrome.runtime.sendMessage(oldExtensionId, data, (response: ScreenshotResponse) => {
             if (!response) {
                 reject();
             }
@@ -45,7 +45,7 @@ export const sendToken = (token: unknown) => {
             reject();
         }
 
-        chrome.runtime.sendMessage(extensionId, data, (response) => {
+        chrome.runtime.sendMessage(oldExtensionId, data, (response) => {
             if (!response) {
                 reject();
             }


### PR DESCRIPTION
## Changes

* Use old extension until new one is deployed for screenshots

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations