### PR TITLE
Fix simplified page being slow due to very large text

### DIFF
--- a/app/components/SubNavbar/index.tsx
+++ b/app/components/SubNavbar/index.tsx
@@ -167,7 +167,10 @@ function SubNavbar(props: SubNavbarProps) {
                     <div
                         className={_cs(styles.descriptionContainer, descriptionContainerClassName)}
                     >
-                        <div className={_cs(styles.description, descriptionClassName)}>
+                        <div
+                            title={description}
+                            className={_cs(styles.description, descriptionClassName)}
+                        >
                             {description}
                         </div>
                     </div>

--- a/app/components/lead/LeadPreview/index.tsx
+++ b/app/components/lead/LeadPreview/index.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react'
 import {
     _cs,
     isDefined,
-    isValidUrl,
     isNotDefined,
 } from '@togglecorp/fujs';
 import {
@@ -19,7 +18,7 @@ import {
 } from '@the-deep/deep-ui';
 
 import ExternalUrlPreview from './ExternalUrlPreview';
-import Viewer from './Preview';
+import Viewer, { isValidUrl } from './Preview';
 import { MimeTypes } from './Preview/mimeTypes';
 
 import styles from './styles.css';

--- a/app/views/Project/EntryEdit/LeftPane/EntryItem/index.tsx
+++ b/app/views/Project/EntryEdit/LeftPane/EntryItem/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
     IoClose,
     IoCheckmark,
@@ -65,7 +65,7 @@ export function ExcerptModal(props: ExcerptModalProps) {
                 name="modified-excerpt"
                 value={excerpt}
                 onChange={setExcerpt}
-                rows={4}
+                rows={10}
             />
             <Footer
                 actions={(
@@ -99,6 +99,7 @@ interface EntryItemProps extends EntryInput {
     errored?: boolean;
     projectId: string | undefined;
     entryServerId: string | undefined;
+    scrollIntoView?: boolean;
 }
 
 function EntryItem(props: EntryItemProps) {
@@ -125,7 +126,22 @@ function EntryItem(props: EntryItemProps) {
         deleted,
         errored,
         stale,
+        scrollIntoView,
     } = props;
+
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    useEffect(
+        () => {
+            if (scrollIntoView && elementRef.current) {
+                elementRef.current.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                });
+            }
+        },
+        [scrollIntoView],
+    );
 
     const editExcerptDropdownRef: QuickActionDropdownMenuProps['componentRef'] = React.useRef(null);
 
@@ -150,6 +166,7 @@ function EntryItem(props: EntryItemProps) {
 
     return (
         <Container
+            elementRef={elementRef}
             className={_cs(
                 styles.taggedExcerpt,
                 className,

--- a/app/views/Project/EntryEdit/LeftPane/EntryItem/index.tsx
+++ b/app/views/Project/EntryEdit/LeftPane/EntryItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import {
     IoClose,
     IoCheckmark,
@@ -99,7 +99,6 @@ interface EntryItemProps extends EntryInput {
     errored?: boolean;
     projectId: string | undefined;
     entryServerId: string | undefined;
-    scrollIntoView?: boolean;
 }
 
 function EntryItem(props: EntryItemProps) {
@@ -126,22 +125,7 @@ function EntryItem(props: EntryItemProps) {
         deleted,
         errored,
         stale,
-        scrollIntoView,
     } = props;
-
-    const elementRef = useRef<HTMLDivElement>(null);
-
-    useEffect(
-        () => {
-            if (scrollIntoView && elementRef.current) {
-                elementRef.current.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'center',
-                });
-            }
-        },
-        [scrollIntoView],
-    );
 
     const editExcerptDropdownRef: QuickActionDropdownMenuProps['componentRef'] = React.useRef(null);
 
@@ -166,7 +150,6 @@ function EntryItem(props: EntryItemProps) {
 
     return (
         <Container
-            elementRef={elementRef}
             className={_cs(
                 styles.taggedExcerpt,
                 className,

--- a/app/views/Project/EntryEdit/LeftPane/EntryItem/styles.css
+++ b/app/views/Project/EntryEdit/LeftPane/EntryItem/styles.css
@@ -44,7 +44,7 @@
 }
 
 .excerpt-text-area {
-    margin: var(--dui-spacing-small);
+    font-size: var(--dui-font-size-medium);
 }
 
 .edit-excerpt-popup {
@@ -52,7 +52,10 @@
     max-width: unset!important;
 
     .content {
-        padding: calc(var(--dui-spacing-medium) - var(--dui-spacing-small));
+        display: flex;
+        flex-direction: column;
+        gap: var(--dui-spacing-medium);
+        padding: var(--dui-spacing-medium);
     }
 }
 

--- a/app/views/Project/EntryEdit/LeftPane/SimplifiedTextView/styles.css
+++ b/app/views/Project/EntryEdit/LeftPane/SimplifiedTextView/styles.css
@@ -7,11 +7,6 @@
     white-space: pre-wrap;
     word-break: break-word;
 
-    * {
-        white-space: pre-wrap;
-        word-break: break-word;
-    }
-
 
     &.disabled {
         user-select: none;

--- a/app/views/Project/EntryEdit/LeftPane/SimplifiedTextView/styles.css
+++ b/app/views/Project/EntryEdit/LeftPane/SimplifiedTextView/styles.css
@@ -1,15 +1,21 @@
 .simplified-text-view {
     --padding: var(--dui-spacing-medium);
 
+    position: relative;
+    padding: var(--padding);
+
+    white-space: pre-wrap;
+    word-break: break-word;
+
+    * {
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+
+
     &.disabled {
         user-select: none;
     }
-
-    position: relative;
-    padding: var(--padding);
-    text-align: justify;
-    white-space: pre-wrap;
-    word-break: break-word;
 
     .entry {
         margin: var(--dui-spacing-medium) 0;
@@ -38,6 +44,12 @@
             font-size: var(--dui-font-size-large);
             user-select: none;
         }
+    }
+
+    .actions {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: var(--dui-spacing-medium);
     }
 }
 

--- a/app/views/Project/EntryEdit/LeftPane/SimplifiedTextView/useTextSelection.ts
+++ b/app/views/Project/EntryEdit/LeftPane/SimplifiedTextView/useTextSelection.ts
@@ -35,10 +35,9 @@ export function useTextSelection(target?: HTMLElement) {
         setText(undefined);
     }, []);
 
+    // FIXME: debounce handler call
     const handler = React.useCallback(() => {
-        let newRect: ClientRect;
         const selection = window.getSelection();
-
         if (selection == null || !selection.rangeCount) {
             reset();
             return;
@@ -46,27 +45,29 @@ export function useTextSelection(target?: HTMLElement) {
 
         const range = selection.getRangeAt(0);
 
-        if (target != null && !target.contains(range.commonAncestorContainer)) {
-            reset();
-            return;
-        }
-
         if (range == null) {
             reset();
             return;
         }
 
-        const contents = range.cloneContents();
+        if (target != null && !target.contains(range.commonAncestorContainer)) {
+            reset();
+            return;
+        }
 
+        const contents = range.cloneContents();
         if (contents.textContent != null) {
             setText(contents.textContent);
         }
 
         const rects = range.getClientRects();
 
+        let newRect: ClientRect | undefined;
         if (rects.length === 0 && range.commonAncestorContainer != null) {
-            const el = range.commonAncestorContainer as HTMLElement;
-            newRect = el.getBoundingClientRect().toJSON();
+            const el = range.commonAncestorContainer;
+            if (el instanceof Element) {
+                newRect = el.getBoundingClientRect().toJSON();
+            }
         } else {
             const lastRect = rects.item(rects.length - 1);
             if (lastRect) {

--- a/app/views/Project/EntryEdit/LeftPane/index.tsx
+++ b/app/views/Project/EntryEdit/LeftPane/index.tsx
@@ -485,7 +485,7 @@ function LeftPane(props: Props) {
                         name="entries"
                         disabled={isEntrySelectionActive}
                     >
-                        All Entries
+                        {`All Entries (${entries?.length ?? 0})`}
                     </Tab>
                 </TabList>
                 {!hideSimplifiedPreview && (

--- a/app/views/Project/EntryEdit/LeftPane/index.tsx
+++ b/app/views/Project/EntryEdit/LeftPane/index.tsx
@@ -18,7 +18,7 @@ import {
     Button,
     QuickActionDropdownMenu,
     QuickActionDropdownMenuProps,
-    ListView,
+    VirtualizedListView,
     Kraken,
     useAlert,
     QuickActionLink,
@@ -274,6 +274,7 @@ function LeftPane(props: Props) {
         onDiscardButtonClick,
         disableClick: isEntrySelectionActive,
         errored: entriesError?.[entryId],
+        className: styles.entryItem,
     }), [
         projectId,
         onApproveButtonClick,
@@ -566,7 +567,10 @@ function LeftPane(props: Props) {
                     activeClassName={styles.entryListTab}
                     retainMount="lazy"
                 >
-                    <ListView
+                    <VirtualizedListView
+                        spacing="none"
+                        direction="vertical"
+                        itemHeight={350}
                         data={entries ?? undefined}
                         renderer={EntryItem}
                         rendererParams={entryItemRendererParams}

--- a/app/views/Project/EntryEdit/LeftPane/index.tsx
+++ b/app/views/Project/EntryEdit/LeftPane/index.tsx
@@ -568,9 +568,9 @@ function LeftPane(props: Props) {
                     retainMount="lazy"
                 >
                     <VirtualizedListView
-                        spacing="none"
+                        spacing="comfortable"
                         direction="vertical"
-                        itemHeight={350}
+                        itemHeight={200}
                         data={entries ?? undefined}
                         renderer={EntryItem}
                         rendererParams={entryItemRendererParams}

--- a/app/views/Project/EntryEdit/LeftPane/styles.css
+++ b/app/views/Project/EntryEdit/LeftPane/styles.css
@@ -35,6 +35,8 @@
     }
 
     .entry-list-tab {
+        display: flex;
+        flex-direction: column;
         flex-grow: 1;
         background-color: var(--dui-color-background-information);
         padding: calc(var(--dui-spacing-large) - var(--dui-spacing-medium));
@@ -43,9 +45,14 @@
         .entry-list {
             display: flex;
             flex-direction: column;
+            flex-grow: 1;
             padding: var(--dui-spacing-medium);
-            overflow-y: auto;
-            gap: var(--dui-spacing-medium);
+            overflow: auto;
+            /* gap: var(--dui-spacing-medium); */
+
+            .entry-item {
+                height: 350px;
+            }
         }
     }
 }

--- a/app/views/Project/EntryEdit/LeftPane/styles.css
+++ b/app/views/Project/EntryEdit/LeftPane/styles.css
@@ -24,7 +24,7 @@
         flex-direction: column;
         flex-grow: 1;
         background-color: var(--dui-color-background-information);
-        padding: var(--dui-spacing-extra-large);
+        padding: var(--dui-spacing-large);
         overflow: auto;
 
         .simplified-text-view {
@@ -34,56 +34,49 @@
         }
     }
 
+    .original-tab {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        background-color: var(--dui-color-background-information);
+        padding: 0;
+
+        .original-preview-container {
+            flex-grow: 1;
+            overflow-y: auto;
+
+            .lead-url-container {
+                align-self: stretch;
+            }
+
+            .content {
+                display: flex;
+                position: relative;
+                flex-direction: column;
+                flex-grow: 1;
+                background-color: var(--dui-color-foreground);
+
+                .preview {
+                    flex-grow: 1;
+                }
+            }
+        }
+    }
+
     .entry-list-tab {
         display: flex;
         flex-direction: column;
         flex-grow: 1;
         background-color: var(--dui-color-background-information);
-        padding: calc(var(--dui-spacing-large) - var(--dui-spacing-medium));
+        padding: var(--dui-spacing-large);
         overflow: auto;
 
         .entry-list {
-            display: flex;
-            flex-direction: column;
             flex-grow: 1;
-            padding: var(--dui-spacing-medium);
             overflow: auto;
-            /* gap: var(--dui-spacing-medium); */
 
             .entry-item {
-                height: 350px;
-            }
-        }
-    }
-}
-
-/*
- NOTE: styling for original tab is moved outside to make it work
- for fullscreen mode
- */
-.original-tab {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-
-    .original-preview-container {
-        flex-grow: 1;
-        background-color: var(--dui-color-background-information);
-        overflow-y: auto;
-
-        .lead-url-container {
-            align-self: stretch;
-        }
-
-        .content {
-            display: flex;
-            position: relative;
-            flex-direction: column;
-            flex-grow: 1;
-            background-color: var(--dui-color-foreground);
-
-            .preview {
-                flex-grow: 1;
+                height: 200px;
             }
         }
     }

--- a/app/views/Project/EntryEdit/index.tsx
+++ b/app/views/Project/EntryEdit/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useRef } from 'react';
 import {
     useParams,
     useLocation,
@@ -288,8 +288,8 @@ function EntryEdit(props: Props) {
 
     const formPristine = !entriesFormStale && leadPristine;
 
-    const [staleIdentifiers, setStaleIdentifiers] = useState<string[] | undefined>(undefined);
-    const [deleteIdentifiers, setDeleteIdentifiers] = useState<string[] | undefined>(undefined);
+    const staleIdentifiersRef = useRef<string[] | undefined>();
+    const deleteIdentifiersRef = useRef<string[] | undefined>();
     const [entryImagesMap, setEntryImagesMap] = useState<EntryImagesMap | undefined>();
 
     const [
@@ -383,6 +383,9 @@ function EntryEdit(props: Props) {
                 const errors = entryBulk?.errors;
                 const deletedResult = response.project?.entryBulk?.deletedResult;
                 const saveResult = response.project?.entryBulk?.result;
+
+                const staleIdentifiers = staleIdentifiersRef.current;
+                const deleteIdentifiers = deleteIdentifiersRef.current;
 
                 const entriesError = errors?.map((item, index) => {
                     if (isNotDefined(item)) {
@@ -521,12 +524,12 @@ function EntryEdit(props: Props) {
                     }
                 }
 
-                setStaleIdentifiers(undefined);
-                setDeleteIdentifiers(undefined);
+                staleIdentifiersRef.current = undefined;
+                deleteIdentifiersRef.current = undefined;
             },
             onError: (gqlError) => {
-                setStaleIdentifiers(undefined);
-                setDeleteIdentifiers(undefined);
+                staleIdentifiersRef.current = undefined;
+                deleteIdentifiersRef.current = undefined;
 
                 alert.show(
                     'Failed to save entries!',
@@ -572,8 +575,8 @@ function EntryEdit(props: Props) {
                     // can be patched later on
                     const deleteIds = deletedEntries?.map((entry) => entry.clientId);
                     const staleIds = staleEntries?.map((entry) => entry.clientId);
-                    setStaleIdentifiers(staleIds);
-                    setDeleteIdentifiers(deleteIds);
+                    staleIdentifiersRef.current = staleIds;
+                    deleteIdentifiersRef.current = deleteIds;
 
                     // NOTE: deleting all the entries that are not saved on server
                     setFormValue((oldValue) => ({
@@ -926,7 +929,7 @@ function EntryEdit(props: Props) {
                     );
                     setEntryImagesMap(imagesMap);
 
-                    if (entries?.some((entry) => entry.clientId === entryIdFromState)) {
+                    if (entries.some((entry) => entry.clientId === entryIdFromState)) {
                         createRestorePoint();
                         setSelectedEntry(entryIdFromState);
                     }

--- a/app/views/Project/EntryEdit/index.tsx
+++ b/app/views/Project/EntryEdit/index.tsx
@@ -12,6 +12,7 @@ import {
     randomString,
     isDefined,
     mapToMap,
+    compareDate,
 } from '@togglecorp/fujs';
 import {
     PendingMessage,
@@ -771,12 +772,12 @@ function EntryEdit(props: Props) {
             createRestorePoint();
             setFormFieldValue(
                 (prevValue: PartialFormType['entries']) => [
+                    ...(prevValue ?? []),
                     {
                         ...newValue,
                         stale: true,
                         attributes: defaultAttributes,
                     },
-                    ...(prevValue ?? []),
                 ],
                 'entries',
             );
@@ -890,9 +891,15 @@ function EntryEdit(props: Props) {
 
                 const leadFromResponse = projectFromResponse.lead;
                 if (leadFromResponse) {
-                    const entries = leadFromResponse.entries?.map(
-                        (entry) => transformEntry(entry as Entry),
-                    );
+                    // FIXME: server sends entries in reverse order
+                    // FIXME: use a better way to sort entries
+                    const entries = [...(leadFromResponse.entries) ?? []]
+                        .sort((foo, bar) => compareDate(
+                            new Date(foo.createdAt),
+                            new Date(bar.createdAt),
+                        ))
+                        .map((entry) => transformEntry(entry as Entry));
+
                     setCommentsCountMap(
                         listToMap(
                             leadFromResponse.entries ?? [],

--- a/app/views/Project/EntryEdit/queries.ts
+++ b/app/views/Project/EntryEdit/queries.ts
@@ -4,6 +4,7 @@ const ENTRY_FRAGMENT = gql`
     fragment EntryResponse on EntryType {
         clientId
         id
+        createdAt
         entryType
         droppedExcerpt
         excerpt


### PR DESCRIPTION
- Limit the amount of characters displayed in simplified text
- Add 'Show more' button at the end of simplified text
- Fix unexpected jumps when adding an entry form simplified text
- Add tooltip for ellipsized text in SubNavbar
- Improve styling of edit excerpt popup
- Check commonAncestorContainer before accessing bounding client rect
- Sort entries from server on ascending order of date created
- Newly added entries are added to the bottom
- Use ref instead of state for storing staleIdentifiers and deleteIdentifiers