### PR TITLE
Replace previous logic for switching section

### DIFF
--- a/app/views/AnalyticalFramework/PrimaryTagging/SectionsEditor/index.tsx
+++ b/app/views/AnalyticalFramework/PrimaryTagging/SectionsEditor/index.tsx
@@ -261,7 +261,7 @@ function SectionsEditor(props: Props) {
         setExpandedSectionId(sectionExpanded ? sectionId : undefined);
     }, []);
 
-    const handleAdd = useCallback(
+    const handleAddSection = useCallback(
         () => {
             const oldSections = value.sections ?? [];
             // NOTE: Don't let users add more that certain items
@@ -357,7 +357,7 @@ function SectionsEditor(props: Props) {
                     headerActions={(value.sections?.length ?? 0) < SECTIONS_LIMIT && (
                         <QuickActionButton
                             name={undefined}
-                            onClick={handleAdd}
+                            onClick={handleAddSection}
                             // FIXME: use strings
                             title="Add section"
                         >

--- a/app/views/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/app/views/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -130,8 +130,11 @@ function PrimaryTaggingInput<K extends string>(props: PrimaryTaggingInput<K>) {
         (value: Section[]) => {
             setTempSections(undefined);
             setSections(value, name);
-            if (sectionToEdit) {
+            if (value?.length > 0 && value.find((tab) => tab.clientId === sectionToEdit)) {
                 setSelectedSection(sectionToEdit);
+            } else {
+                const firstTab = value?.length > 0 ? value[0].clientId : undefined;
+                setSelectedSection(firstTab);
             }
         },
         [setSections, name, sectionToEdit],

--- a/app/views/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/app/views/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -119,6 +119,7 @@ function PrimaryTaggingInput<K extends string>(props: PrimaryTaggingInput<K>) {
     const handleSectionsEditCancel = useCallback(
         () => {
             setTempSections(undefined);
+            setSectionToEdit(undefined);
         },
         [],
     );
@@ -129,8 +130,11 @@ function PrimaryTaggingInput<K extends string>(props: PrimaryTaggingInput<K>) {
         (value: Section[]) => {
             setTempSections(undefined);
             setSections(value, name);
+            if (sectionToEdit) {
+                setSelectedSection(sectionToEdit);
+            }
         },
-        [setSections, name],
+        [setSections, name, sectionToEdit],
     );
 
     const handleWidgetAdd = useCallback(

--- a/app/views/AnalyticalFramework/PrimaryTagging/index.tsx
+++ b/app/views/AnalyticalFramework/PrimaryTagging/index.tsx
@@ -130,7 +130,9 @@ function PrimaryTaggingInput<K extends string>(props: PrimaryTaggingInput<K>) {
         (value: Section[]) => {
             setTempSections(undefined);
             setSections(value, name);
-            if (value?.length > 0 && value.find((tab) => tab.clientId === sectionToEdit)) {
+            if (value?.length < 0) {
+                setSelectedSection(undefined);
+            } else if (value.find((tab) => tab.clientId === sectionToEdit)) {
                 setSelectedSection(sectionToEdit);
             } else {
                 const firstTab = value?.length > 0 ? value[0].clientId : undefined;


### PR DESCRIPTION
## Changes:
- Fix issue regarding the section tab not changing to latest (added or edited) in framework details 

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [ ] permission checks
- [ ] translations
