### PR TITLE
Add leads ordering by number of pages

### DIFF
--- a/app/views/Project/Tagging/Export/LeadsSelection/index.tsx
+++ b/app/views/Project/Tagging/Export/LeadsSelection/index.tsx
@@ -23,6 +23,7 @@ import { useQuery, gql } from '@apollo/client';
 
 import { organizationTitleSelector } from '#components/selections/NewOrganizationSelectInput';
 import {
+    LeadOrderingEnum,
     ProjectSourceListQuery,
     ProjectSourceListQueryVariables,
     SourceFilterOptionsQueryVariables,
@@ -35,7 +36,7 @@ type Project = NonNullable<ProjectSourceListQuery['project']>;
 type Lead = NonNullable<NonNullable<NonNullable<Project['leads']>['results']>[number]>;
 
 const defaultSorting = {
-    name: 'createdAt',
+    name: 'CREATED_AT',
     direction: 'Descending',
 };
 
@@ -49,7 +50,7 @@ const PROJECT_LEADS = gql`
         $projectId: ID!,
         $page: Int,
         $pageSize: Int,
-        $ordering: String,
+        $ordering: [LeadOrderingEnum!],
         $assignees: [ID!],
         $authoringOrganizationTypes: [ID!],
         $confidentiality: LeadConfidentialityEnum,
@@ -169,8 +170,8 @@ function LeadsSelection(props: Props) {
     const { sorting } = sortState;
     const validSorting = sorting || defaultSorting;
     const ordering = validSorting.direction === 'Ascending'
-        ? validSorting.name
-        : `-${validSorting.name}`;
+        ? `ASC_${validSorting.name}`
+        : `DESC_${validSorting.name}`;
 
     const [activePage, setActivePage] = useState<number>(1);
 
@@ -185,7 +186,7 @@ function LeadsSelection(props: Props) {
                 projectId,
                 page: activePage,
                 pageSize: maxItemsPerPage,
-                ordering,
+                ordering: [ordering as LeadOrderingEnum],
             } : undefined
         ),
         [projectId, activePage, ordering, filters],
@@ -242,7 +243,7 @@ function LeadsSelection(props: Props) {
         const createdAtColumn: TableColumn<
         Lead, string, DateOutputProps, TableHeaderCellProps
         > = {
-            id: 'createdAt',
+            id: 'CREATED_AT',
             title: 'Created at',
             headerCellRenderer: TableHeaderCell,
             headerCellRendererParams: {
@@ -257,7 +258,7 @@ function LeadsSelection(props: Props) {
         const publishedOnColumn: TableColumn<
         Lead, string, DateOutputProps, TableHeaderCellProps
         > = {
-            id: 'publishedOn',
+            id: 'PUBLISHED_ON',
             title: 'Published Date',
             headerCellRenderer: TableHeaderCell,
             headerCellRendererParams: {
@@ -274,7 +275,7 @@ function LeadsSelection(props: Props) {
             selectColumn,
             createdAtColumn,
             createStringColumn<Lead, string>(
-                'title',
+                'TITLE',
                 'Title',
                 (item) => item?.title,
                 {
@@ -283,7 +284,7 @@ function LeadsSelection(props: Props) {
                 },
             ),
             createStringColumn<Lead, string>(
-                'source',
+                'SOURCE',
                 'Publisher',
                 (item) => (item.source ? organizationTitleSelector(item.source) : undefined),
                 {
@@ -302,11 +303,11 @@ function LeadsSelection(props: Props) {
             ),
             publishedOnColumn,
             createNumberColumn<Lead, string>(
-                'entriesCounts',
+                'ENTRIES_COUNTS',
                 'No of entries',
                 (item) => item?.entriesCounts?.total,
                 {
-                    sortable: true,
+                    sortable: false,
                 },
             ),
         ]);

--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -39,6 +39,7 @@ import {
     ProjectSourcesQueryVariables,
     DeleteLeadMutation,
     DeleteLeadMutationVariables,
+    LeadOrderingEnum,
 } from '#generated/types';
 import _ts from '#ts';
 import { createDateColumn } from '#components/tableHelpers';
@@ -82,7 +83,7 @@ const statusVariantMap: Record<Lead['status'], 'default' | 'gradient1' | 'comple
 };
 
 const defaultSorting = {
-    name: 'createdAt',
+    name: 'CREATED_AT',
     direction: 'Descending',
 };
 
@@ -91,7 +92,7 @@ export const PROJECT_SOURCES = gql`
         $projectId: ID!,
         $page: Int,
         $pageSize: Int,
-        $ordering: String,
+        $ordering: [LeadOrderingEnum!],
         $assignees: [ID!],
         $authoringOrganizationTypes: [ID!],
         $confidentiality: LeadConfidentialityEnum,
@@ -270,8 +271,8 @@ function SourcesTable(props: Props) {
     const { sorting } = sortState;
     const validSorting = sorting || defaultSorting;
     const ordering = validSorting.direction === 'Ascending'
-        ? validSorting.name
-        : `-${validSorting.name}`;
+        ? `ASC_${validSorting.name}`
+        : `DESC_${validSorting.name}`;
 
     const variables = useMemo(
         (): ProjectSourcesQueryVariables | undefined => {
@@ -283,7 +284,7 @@ function SourcesTable(props: Props) {
                 projectId,
                 page: activePage,
                 pageSize: maxItemsPerPage,
-                ordering,
+                ordering: [ordering as LeadOrderingEnum],
             });
         },
         [projectId, activePage, ordering, filters, maxItemsPerPage],
@@ -484,7 +485,7 @@ function SourcesTable(props: Props) {
         const leadTitleColumn: TableColumn<
             Lead, string, LeadPreviewProps, TableHeaderCellProps
         > = {
-            id: 'title',
+            id: 'TITLE',
             title: _ts('sourcesTable', 'titleLabel'),
             headerCellRenderer: TableHeaderCell,
             headerCellRendererParams: {
@@ -503,7 +504,7 @@ function SourcesTable(props: Props) {
         const publisherColumn: TableColumn<
             Lead, string, SourceLinkProps, TableHeaderCellProps
         > = {
-            id: 'source',
+            id: 'SOURCE',
             title: _ts('sourcesTable', 'publisher'),
             headerCellRenderer: TableHeaderCell,
             headerCellRendererParams: {
@@ -560,7 +561,7 @@ function SourcesTable(props: Props) {
             selectColumn,
             statusColumn,
             createDateColumn<Lead, string>(
-                'createdAt',
+                'CREATED_AT',
                 _ts('sourcesTable', 'createdAt'),
                 (item) => item.createdAt,
                 {
@@ -570,7 +571,7 @@ function SourcesTable(props: Props) {
             ),
             leadTitleColumn,
             createStringColumn<Lead, string>(
-                'pageCount',
+                'PAGE_COUNT',
                 _ts('sourcesTable', 'pages'),
                 (item) => {
                     if (!item.leadPreview?.pageCount) {
@@ -579,6 +580,7 @@ function SourcesTable(props: Props) {
                     return `${item.leadPreview.pageCount} ${item.leadPreview.pageCount > 1 ? 'pages' : 'page'}`;
                 },
                 {
+                    sortable: true,
                     columnWidth: 96,
                 },
             ),
@@ -593,7 +595,7 @@ function SourcesTable(props: Props) {
                 },
             ),
             createDateColumn<Lead, string>(
-                'publishedOn',
+                'PUBLISHED_ON',
                 'Published On',
                 (item) => item.publishedOn ?? '',
                 {
@@ -602,7 +604,7 @@ function SourcesTable(props: Props) {
                 },
             ),
             createStringColumn<Lead, string>(
-                'createdBy',
+                'CREATED_BY',
                 _ts('sourcesTable', 'addedBy'),
                 (item) => item.createdBy?.displayName,
                 {
@@ -611,7 +613,7 @@ function SourcesTable(props: Props) {
                 },
             ),
             createStringColumn<Lead, string>(
-                'assignee',
+                'ASSIGNEE',
                 _ts('sourcesTable', 'assignee'),
                 (item) => item.assignee?.displayName,
                 {
@@ -620,7 +622,7 @@ function SourcesTable(props: Props) {
                 },
             ),
             createStringColumn<Lead, string>(
-                'priority',
+                'PRIORITY',
                 _ts('sourcesTable', 'priority'),
                 (item) => item.priorityDisplay,
                 {


### PR DESCRIPTION
- fixes #2357
- Depends on https://github.com/the-deep/server/tree/feature/lead-order-fix

* Detailed list or prose of changes
* Breaking changes
* Changes to configurations

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [ ] permission checks
- [ ] translations
