### PR TITLE
Fix lead preview modal to use attachment and url from props

### DIFF
--- a/app/components/lead/LeadPreviewButton/index.tsx
+++ b/app/components/lead/LeadPreviewButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { _cs } from '@togglecorp/fujs';
 import {
     Button,
@@ -7,45 +7,19 @@ import {
     Message,
     Kraken,
 } from '@the-deep/deep-ui';
-import { useQuery, gql } from '@apollo/client';
 
-import LeadPreview from '#components/lead/LeadPreview';
+import LeadPreview, { Attachment } from '#components/lead/LeadPreview';
 import { useModalState } from '#hooks/stateManagement';
-import {
-    ProjectLeadPreviewQuery,
-    ProjectLeadPreviewQueryVariables,
-} from '#generated/types';
 
 import styles from './styles.css';
-
-const PROJECT_LEAD_PREVIEW = gql`
-    query ProjectLeadPreview($projectId: ID!, $leadId: ID!) {
-        project(id: $projectId) {
-            id
-            lead (id: $leadId) {
-                id
-                title
-                url
-                attachment {
-                    id
-                    title
-                    mimeType
-                    file {
-                        url
-                    }
-                }
-            }
-        }
-    }
-`;
 
 export type Props = {
     label?: React.ReactNode;
     title?: string;
+    url?: string;
     className?: string;
+    attachment?: Attachment | null;
     variant?: ButtonProps<string>['variant'];
-    projectId?: string;
-    leadId?: string;
 }
 
 function LeadPreviewButton(props: Props) {
@@ -54,30 +28,9 @@ function LeadPreviewButton(props: Props) {
         label,
         variant,
         title,
-        projectId,
-        leadId,
+        url,
+        attachment,
     } = props;
-
-    const variables = useMemo(
-        () => ((leadId && projectId) ? ({
-            leadId,
-            projectId,
-        }) : undefined),
-        [leadId, projectId],
-    );
-
-    const {
-        loading: leadLoading,
-        data: lead,
-    } = useQuery<ProjectLeadPreviewQuery, ProjectLeadPreviewQueryVariables>(
-        PROJECT_LEAD_PREVIEW,
-        {
-            skip: !variables,
-            variables,
-        },
-    );
-
-    const leadData = lead?.project?.lead;
 
     const [
         isModalVisible,
@@ -87,7 +40,7 @@ function LeadPreviewButton(props: Props) {
 
     return (
         <>
-            {(!projectId && !leadId) ? (
+            {(!url && !attachment) ? (
                 label
             ) : (
                 <Button
@@ -113,16 +66,15 @@ function LeadPreviewButton(props: Props) {
                     bodyClassName={styles.content}
                     spacing="none"
                 >
-                    {(!leadLoading && (leadData?.url || leadData?.attachment)) ? (
+                    {(url || attachment) ? (
                         <LeadPreview
                             className={styles.preview}
-                            url={leadData?.url ?? undefined}
-                            attachment={leadData?.attachment ?? undefined}
+                            url={url ?? undefined}
+                            attachment={attachment ?? undefined}
                         />
                     ) : (
                         <Message
                             icon={<Kraken variant="sleep" />}
-                            pending={leadLoading}
                             message="No preview available"
                         />
                     )}

--- a/app/views/Project/Tagging/Sources/EntriesGrid/EntryCard/index.tsx
+++ b/app/views/Project/Tagging/Sources/EntriesGrid/EntryCard/index.tsx
@@ -165,10 +165,10 @@ function EntryCard(props: Props) {
                         {leadDetails.title}
                         <LeadPreviewButton
                             className={styles.previewButton}
-                            leadId={leadDetails.id}
-                            projectId={projectId}
                             label={<IoEye />}
                             title={leadDetails.title}
+                            url={leadDetails.url}
+                            attachment={leadDetails.attachment}
                         />
                     </>
                 )}

--- a/app/views/Project/Tagging/Sources/EntriesGrid/index.tsx
+++ b/app/views/Project/Tagging/Sources/EntriesGrid/index.tsx
@@ -117,6 +117,15 @@ export const PROJECT_ENTRIES = gql`
                         createdBy {
                             displayName
                         }
+                        url
+                        attachment {
+                            id
+                            title
+                            mimeType
+                            file {
+                                url
+                            }
+                        }
                     }
                     attributes {
                         clientId

--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -146,6 +146,15 @@ export const PROJECT_SOURCES = gql`
                     publishedOn
                     priority
                     priorityDisplay
+                    url
+                    attachment {
+                        id
+                        title
+                        mimeType
+                        file {
+                            url
+                        }
+                    }
                     assessmentId
                     createdBy {
                         id
@@ -483,10 +492,10 @@ function SourcesTable(props: Props) {
             },
             cellRenderer: LeadPreviewButton,
             cellRendererParams: (_, data) => ({
-                leadId: data.id,
-                projectId,
                 title: data.title,
                 label: data.title,
+                url: data.url,
+                attachment: data.attachment,
             }),
             columnClassName: styles.titleColumn,
             columnWidth: 160,


### PR DESCRIPTION
## Changes

* Send lead url and attachment from props to LeadPreviewButton

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations