### PR TITLE
Replace namespace by source in confirm msg

### DIFF
--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -317,7 +317,7 @@ function SourcesTable(props: Props) {
             onCompleted: (response) => {
                 if (response?.project?.leadDelete?.ok) {
                     alert.show(
-                        'Successfully deleted lead.',
+                        'Successfully deleted source.',
                         {
                             variant: 'success',
                         },
@@ -325,7 +325,7 @@ function SourcesTable(props: Props) {
                     getProjectSources();
                 } else {
                     alert.show(
-                        'Failed to delete lead.',
+                        'Failed to delete source.',
                         {
                             variant: 'error',
                         },
@@ -334,7 +334,7 @@ function SourcesTable(props: Props) {
             },
             onError: () => {
                 alert.show(
-                    'Failed to delete lead.',
+                    'Failed to delete source.',
                     {
                         variant: 'error',
                     },
@@ -457,7 +457,7 @@ function SourcesTable(props: Props) {
                 // { noOfSources: selectedLeads.length }) : _ts('sourcesTable', 'selectAll'),
                 onChange: handleSelectAll,
                 indeterminate: !(selectedLeads.length === sources?.length
-                || selectedLeads.length === 0),
+                    || selectedLeads.length === 0),
             },
             cellRenderer: Checkbox,
             cellRendererParams: (_, data) => ({


### PR DESCRIPTION
## Changes:
- Replace the namespace "lead" by "source" in the source delete confirmation message

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [ ] permission checks
- [ ] translations
