### PR TITLE
Feature/lead batch requests

### DIFF
--- a/app/Base/components/Navbar/index.tsx
+++ b/app/Base/components/Navbar/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useContext, useRef, useEffect } from 'react';
 import { _cs } from '@togglecorp/fujs';
 import { Link } from 'react-router-dom';
-import { useQuery, gql, useMutation } from '@apollo/client';
+import { useQuery, useMutation } from '@apollo/client';
 import {
     Border,
     QuickActionLink,
@@ -38,27 +38,11 @@ import {
 } from '#generated/types';
 import deepLogo from '#resources/img/deep-logo-new.svg';
 
+import { LOGOUT, USER_NOTIFICATIONS_COUNT } from './queries';
+
 import styles from './styles.css';
 
 const NOTIFICATION_POLL_INTERVAL = 60000;
-
-const LOGOUT = gql`
-    mutation Logout {
-        logout {
-            ok
-        }
-    }
-`;
-
-export const USER_NOTIFICATIONS_COUNT = gql`
-    query UserNotificationsCount {
-        notifications(
-            status: UNSEEN,
-        ) {
-            totalCount
-        }
-    }
-`;
 
 interface Props {
     className?: string;
@@ -256,7 +240,7 @@ function Navbar(props: Props) {
                     <DropdownMenuItem
                         href={extensionChromeUrl}
                         linkProps={{
-                            // FIXME: we shouldn't need to add "to" here
+                            // FIXME: we should not need to add "to" here
                             to: extensionChromeUrl,
                             target: '_blank',
                             rel: 'noopener noreferrer',

--- a/app/Base/components/Navbar/queries.ts
+++ b/app/Base/components/Navbar/queries.ts
@@ -1,0 +1,19 @@
+import { gql } from '@apollo/client';
+
+export const LOGOUT = gql`
+    mutation Logout {
+        logout {
+            ok
+        }
+    }
+`;
+
+export const USER_NOTIFICATIONS_COUNT = gql`
+    query UserNotificationsCount {
+        notifications(
+            status: UNSEEN,
+        ) {
+            totalCount
+        }
+    }
+`;

--- a/app/Base/configs/apollo.ts
+++ b/app/Base/configs/apollo.ts
@@ -1,4 +1,11 @@
-import { ApolloClientOptions, NormalizedCacheObject, InMemoryCache, ApolloLink as ApolloLinkFromClient, HttpLink } from '@apollo/client';
+import {
+    ApolloClient,
+    ApolloClientOptions,
+    NormalizedCacheObject,
+    InMemoryCache,
+    ApolloLink as ApolloLinkFromClient,
+    HttpLink,
+} from '@apollo/client';
 import { ApolloLink } from 'apollo-link';
 import { RetryLink } from 'apollo-link-retry';
 import { createUploadLink } from 'apollo-upload-client';
@@ -47,4 +54,5 @@ const apolloOptions: ApolloClientOptions<NormalizedCacheObject> = {
     },
 };
 
-export default apolloOptions;
+// eslint-disable-next-line import/prefer-default-export
+export const apolloClient = new ApolloClient(apolloOptions);

--- a/app/Base/index.tsx
+++ b/app/Base/index.tsx
@@ -10,7 +10,7 @@ import {
     AlertOptions,
     Button,
 } from '@the-deep/deep-ui';
-import { ApolloClient, ApolloProvider } from '@apollo/client';
+import { ApolloProvider } from '@apollo/client';
 import ReactGA from 'react-ga';
 import { setMapboxToken } from '@togglecorp/re-map';
 
@@ -30,7 +30,6 @@ import { sync } from '#base/hooks/useAuthSync';
 import Navbar from '#base/components/Navbar';
 import Routes from '#base/components/Routes';
 import { User } from '#base/types/user';
-import apolloConfig from '#base/configs/apollo';
 import { trackingId, gaConfig } from '#base/configs/googleAnalytics';
 import {
     processDeepUrls,
@@ -42,6 +41,7 @@ import {
 } from '#base/utils/restRequest';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
+import { apolloClient } from '#base/configs/apollo';
 import localforageInstance from '#base/configs/localforage';
 import { mapboxToken } from '#base/configs/env';
 
@@ -65,8 +65,6 @@ browserHistory.listen((location) => {
     ReactGA.set({ page });
     ReactGA.pageview(page);
 });
-
-const apolloClient = new ApolloClient(apolloConfig);
 
 function Base() {
     const [user, setUser] = useState<User | undefined>();

--- a/app/components/Notifications/NotificationContainer/index.tsx
+++ b/app/components/Notifications/NotificationContainer/index.tsx
@@ -18,7 +18,9 @@ import {
     Container,
     DateOutput,
 } from '@the-deep/deep-ui';
+import { getOperationName } from 'apollo-link';
 
+import { USER_NOTIFICATIONS_COUNT } from '#base/components/Navbar/queries';
 import Avatar from '#components/Avatar';
 import { useModalState } from '#hooks/stateManagement';
 
@@ -91,7 +93,7 @@ function NotificationContainer(props: Props) {
     ] = useMutation<NotificationStatusUpdateMutation, NotificationStatusUpdateMutationVariables>(
         NOTIFICATION_STATUS_UPDATE,
         {
-            refetchQueries: ['UserNotificationsCount'],
+            refetchQueries: [getOperationName(USER_NOTIFICATIONS_COUNT)].filter(isDefined),
             onCompleted: (response) => {
                 if (response?.notificationStatusUpdate?.ok) {
                     const newStatus = response.notificationStatusUpdate?.result?.statusDisplay;

--- a/app/components/Notifications/NotificationItem/ProjectJoinRequestItem/index.tsx
+++ b/app/components/Notifications/NotificationItem/ProjectJoinRequestItem/index.tsx
@@ -1,5 +1,8 @@
 import React, { useCallback } from 'react';
-import { _cs } from '@togglecorp/fujs';
+import {
+    _cs,
+    isDefined,
+} from '@togglecorp/fujs';
 import { gql, useMutation } from '@apollo/client';
 import {
     IoClose,
@@ -9,6 +12,7 @@ import {
     Button,
     useAlert,
 } from '@the-deep/deep-ui';
+import { getOperationName } from 'apollo-link';
 
 import generateString from '#utils/string';
 import {
@@ -21,6 +25,8 @@ import {
     ProjectJoinRequest,
 } from '../../types';
 import NotificationContainer from '../../NotificationContainer';
+
+import { USER_NOTIFICATIONS_COUNT } from '#base/components/Navbar/queries';
 
 import styles from './styles.css';
 
@@ -66,7 +72,7 @@ function ProjectJoinRequestItem(props: Props) {
     ] = useMutation<JoinRequestAcceptRejectMutation, JoinRequestAcceptRejectMutationVariables>(
         JOIN_REQUEST_ACCEPT_REJECT,
         {
-            refetchQueries: ['UserNotificationsCount'],
+            refetchQueries: [getOperationName(USER_NOTIFICATIONS_COUNT)].filter(isDefined),
             onCompleted: (response) => {
                 if (response?.project?.acceptRejectProject?.ok) {
                     const status = response.project.acceptRejectProject?.result?.status;

--- a/app/hooks/useBatchManager.ts
+++ b/app/hooks/useBatchManager.ts
@@ -19,7 +19,7 @@ interface FailedRequestItem<K, Req, Err> {
     error: Err,
 }
 
-type RequestItem<K, Req, Res, Err> = PendingRequestItem<K, Req>
+export type RequestItem<K, Req, Res, Err> = PendingRequestItem<K, Req>
     | CompletedRequestItem<K, Req, Res>
     | FailedRequestItem<K, Req, Err>;
 
@@ -39,6 +39,7 @@ export function filterPending<K, Req, Res, Err>(
     return item.status === 'pending';
 }
 
+// TODO: show progress
 function useBatchManager<K, Req, Res, Err>() {
     const requestItems = useRef<RequestItem<K, Req, Res, Err>[]>([]);
 

--- a/app/hooks/useBatchManager.ts
+++ b/app/hooks/useBatchManager.ts
@@ -1,0 +1,133 @@
+import { useRef, useCallback } from 'react';
+import { isDefined } from '@togglecorp/fujs';
+
+interface PendingRequestItem<K, Req> {
+    key: K;
+    request: Req;
+    status: 'pending';
+}
+interface CompletedRequestItem<K, Req, Res> {
+    key: K;
+    request: Req;
+    status: 'completed';
+    response: Res,
+}
+interface FailedRequestItem<K, Req, Err> {
+    key: K;
+    request: Req;
+    status: 'failed';
+    error: Err,
+}
+
+type RequestItem<K, Req, Res, Err> = PendingRequestItem<K, Req>
+    | CompletedRequestItem<K, Req, Res>
+    | FailedRequestItem<K, Req, Err>;
+
+export function filterFailed<K, Req, Res, Err>(
+    item: RequestItem<K, Req, Res, Err>,
+): item is FailedRequestItem<K, Req, Err> {
+    return item.status === 'failed';
+}
+export function filterCompleted<K, Req, Res, Err>(
+    item: RequestItem<K, Req, Res, Err>,
+): item is CompletedRequestItem<K, Req, Res> {
+    return item.status === 'completed';
+}
+export function filterPending<K, Req, Res, Err>(
+    item: RequestItem<K, Req, Res, Err>,
+): item is PendingRequestItem<K, Req> {
+    return item.status === 'pending';
+}
+
+function useBatchManager<K, Req, Res, Err>() {
+    const requestItems = useRef<RequestItem<K, Req, Res, Err>[]>([]);
+
+    const startIndex = useRef(0);
+    const endIndex = useRef(0);
+
+    const init = useCallback(
+        (requests: Req[], keySelector: (req: Req) => K) => {
+            startIndex.current = 0;
+            endIndex.current = 0;
+            requestItems.current = requests.map((request) => ({
+                key: keySelector(request),
+                request,
+                status: 'pending',
+            }));
+        },
+        [],
+    );
+
+    const reset = useCallback(
+        () => {
+            startIndex.current = 0;
+            endIndex.current = 0;
+            requestItems.current = [];
+        },
+        [],
+    );
+
+    const pop = useCallback(
+        // FIXME: change default batchSize
+        (batchSize = 2) => {
+            if (startIndex.current === 0 && endIndex.current === 0) {
+                startIndex.current = 0;
+                endIndex.current = Math.max(
+                    batchSize,
+                    requestItems.current.length,
+                );
+            } else {
+                startIndex.current = Math.max(
+                    startIndex.current + batchSize,
+                    requestItems.current.length,
+                );
+                endIndex.current = Math.max(
+                    endIndex.current + batchSize,
+                    requestItems.current.length,
+                );
+            }
+            const output = requestItems.current.slice(
+                startIndex.current,
+                endIndex.current,
+            ).map((item) => item.request);
+            return output;
+        },
+        [],
+    );
+
+    const update = useCallback(
+        (
+            merger: (
+                oldValue: RequestItem<K, Req, Res, Err>,
+                localIndex: number,
+                index: number,
+            ) => RequestItem<K, Req, Res, Err>,
+        ) => {
+            for (let i = startIndex.current; i < endIndex.current; i += 1) {
+                const oldValue = requestItems.current[i];
+                if (isDefined(oldValue)) {
+                    requestItems.current[i] = merger(oldValue, i - startIndex.current, i);
+                } else {
+                    // eslint-disable-next-line no-console
+                    console.error(`Element not found at ${i}`);
+                }
+            }
+        },
+        [],
+    );
+
+    const inspect = useCallback(
+        () => requestItems.current,
+        [],
+    );
+
+    return {
+        inspect,
+        init,
+        pop,
+        update,
+        reset,
+    };
+}
+
+export default useBatchManager;

--- a/app/hooks/useBatchManager.ts
+++ b/app/hooks/useBatchManager.ts
@@ -72,16 +72,16 @@ function useBatchManager<K, Req, Res, Err>() {
         (batchSize = 2) => {
             if (startIndex.current === 0 && endIndex.current === 0) {
                 startIndex.current = 0;
-                endIndex.current = Math.max(
+                endIndex.current = Math.min(
                     batchSize,
                     requestItems.current.length,
                 );
             } else {
-                startIndex.current = Math.max(
+                startIndex.current = Math.min(
                     startIndex.current + batchSize,
                     requestItems.current.length,
                 );
-                endIndex.current = Math.max(
+                endIndex.current = Math.min(
                     endIndex.current + batchSize,
                     requestItems.current.length,
                 );

--- a/app/views/Project/Tagging/Export/AssessmentsExportSelection/index.tsx
+++ b/app/views/Project/Tagging/Export/AssessmentsExportSelection/index.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useCallback } from 'react';
-import { _cs } from '@togglecorp/fujs';
+import {
+    _cs,
+    isDefined,
+} from '@togglecorp/fujs';
 import {
     Footer,
     useAlert,
@@ -7,6 +10,7 @@ import {
     Button,
     ControlledExpandableContainer,
 } from '@the-deep/deep-ui';
+import { getOperationName } from 'apollo-link';
 import { gql, useMutation } from '@apollo/client';
 import {
     CreateExportMutation,
@@ -17,6 +21,7 @@ import {
 import ProjectContext from '#base/context/ProjectContext';
 import _ts from '#ts';
 
+import { PROJECT_EXPORTS } from '#views/Project/Tagging/Export/ExportHistory/queries';
 import ExportPreview from '../ExportPreview';
 import LeadsSelection from '../LeadsSelection';
 
@@ -74,9 +79,7 @@ function AssessmentsExportSelection(props: Props) {
     ] = useMutation<CreateExportMutation, CreateExportMutationVariables>(
         CREATE_EXPORT,
         {
-            refetchQueries: [
-                'ProjectExports',
-            ],
+            refetchQueries: [getOperationName(PROJECT_EXPORTS)].filter(isDefined),
             onCompleted: (response) => {
                 if (response?.project?.exportCreate?.ok) {
                     if (response.project.exportCreate.result?.isPreview) {

--- a/app/views/Project/Tagging/Export/EntriesExportSelection/index.tsx
+++ b/app/views/Project/Tagging/Export/EntriesExportSelection/index.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { _cs } from '@togglecorp/fujs';
+import {
+    _cs,
+    isDefined,
+} from '@togglecorp/fujs';
 import {
     Button,
     useAlert,
@@ -7,6 +10,7 @@ import {
     TextInput,
 } from '@the-deep/deep-ui';
 import { gql, useQuery, useMutation } from '@apollo/client';
+import { getOperationName } from 'apollo-link';
 
 import _ts from '#ts';
 import {
@@ -22,6 +26,8 @@ import {
     ExportFormatEnum,
 } from '#generated/types';
 import ProjectContext from '#base/context/ProjectContext';
+import { PROJECT_EXPORTS } from '#views/Project/Tagging/Export/ExportHistory/queries';
+
 import {
     Node,
     TreeSelectableWidget,
@@ -261,9 +267,7 @@ function EntriesExportSelection(props: Props) {
     ] = useMutation<CreateExportMutation, CreateExportMutationVariables>(
         CREATE_EXPORT,
         {
-            refetchQueries: [
-                'ProjectExports',
-            ],
+            refetchQueries: [getOperationName(PROJECT_EXPORTS)].filter(isDefined),
             onCompleted: (response) => {
                 if (response?.project?.exportCreate?.ok) {
                     if (response.project.exportCreate.result?.isPreview) {

--- a/app/views/Project/Tagging/Export/ExportHistory/index.tsx
+++ b/app/views/Project/Tagging/Export/ExportHistory/index.tsx
@@ -27,7 +27,7 @@ import {
     TextInput,
     DateRangeInput,
 } from '@the-deep/deep-ui';
-import { useQuery, gql, useMutation } from '@apollo/client';
+import { useQuery, useMutation } from '@apollo/client';
 
 import {
     ProjectExportsQuery,
@@ -45,6 +45,7 @@ import LeadPreview from '#components/lead/LeadPreview';
 
 import _ts from '#ts';
 
+import { PROJECT_EXPORTS, DELETE_EXPORT } from './queries';
 import TableActions, { Props as TableActionsProps } from './TableActions';
 import Status, { Props as StatusProps } from './Status';
 import styles from './styles.css';
@@ -93,63 +94,6 @@ interface DateRangeValue {
     endDate: string;
 }
 
-const PROJECT_EXPORTS = gql`
-    query ProjectExports(
-        $projectId: ID!,
-        $page: Int,
-        $pageSize: Int,
-        $ordering: String,
-        $exportedAtGte: DateTime,
-        $exportedAtLte: DateTime,
-        $search: String,
-        $type: [ExportDataTypeEnum!],
-    ) {
-        project(id: $projectId) {
-            id
-            exports (
-                page: $page,
-                pageSize: $pageSize,
-                ordering: $ordering,
-                exportedAtGte: $exportedAtGte,
-                exportedAtLte: $exportedAtLte,
-                search: $search,
-                type: $type,
-            ) {
-                totalCount
-                page
-                pageSize
-                results {
-                    id
-                    title
-                    exportType
-                    exportedAt
-                    status
-                    format
-                    file {
-                        name
-                        url
-                    }
-                }
-            }
-        }
-    }
-`;
-
-const DELETE_EXPORT = gql`
-    mutation DeleteExport(
-        $projectId: ID!,
-        $exportId: ID!,
-    ) {
-        project(id: $projectId) {
-            id
-            exportDelete(id: $exportId) {
-                ok
-                errors
-            }
-        }
-    }
-`;
-
 const debounceTime = 500;
 
 interface Props {
@@ -169,6 +113,7 @@ function ExportHistory(props: Props) {
     const [activePage, setActivePage] = useState(1);
     const [exportedAt, setExportedAt] = useState<DateRangeValue>();
     const [searchText, setSearchText] = useState<string>();
+    // FIXME: we can safely remove useDebouncedValue if we are using TextInput from deep-ui
     const debouncedSearchText = useDebouncedValue(searchText, debounceTime);
 
     const handleSetSearchText = useCallback((search: string | undefined) => {

--- a/app/views/Project/Tagging/Export/ExportHistory/queries.ts
+++ b/app/views/Project/Tagging/Export/ExportHistory/queries.ts
@@ -1,0 +1,58 @@
+import { gql } from '@apollo/client';
+
+export const PROJECT_EXPORTS = gql`
+    query ProjectExports(
+        $projectId: ID!,
+        $page: Int,
+        $pageSize: Int,
+        $ordering: String,
+        $exportedAtGte: DateTime,
+        $exportedAtLte: DateTime,
+        $search: String,
+        $type: [ExportDataTypeEnum!],
+    ) {
+        project(id: $projectId) {
+            id
+            exports (
+                page: $page,
+                pageSize: $pageSize,
+                ordering: $ordering,
+                exportedAtGte: $exportedAtGte,
+                exportedAtLte: $exportedAtLte,
+                search: $search,
+                type: $type,
+            ) {
+                totalCount
+                page
+                pageSize
+                results {
+                    id
+                    title
+                    exportType
+                    exportedAt
+                    status
+                    format
+                    file {
+                        name
+                        url
+                    }
+                }
+            }
+        }
+    }
+`;
+
+export const DELETE_EXPORT = gql`
+    mutation DeleteExport(
+        $projectId: ID!,
+        $exportId: ID!,
+    ) {
+        project(id: $projectId) {
+            id
+            exportDelete(id: $exportId) {
+                ok
+                errors
+            }
+        }
+    }
+`;

--- a/app/views/Project/Tagging/Sources/BulkUpload/Upload/UploadItem/index.tsx
+++ b/app/views/Project/Tagging/Sources/BulkUpload/Upload/UploadItem/index.tsx
@@ -3,6 +3,7 @@ import { _cs } from '@togglecorp/fujs';
 import {
     QuickActionButton,
     ElementFragments,
+    Spinner,
 } from '@the-deep/deep-ui';
 import { AiOutlineRedo } from 'react-icons/ai';
 import { IoDocumentOutline, IoLogoDropbox } from 'react-icons/io5';
@@ -110,7 +111,7 @@ function UploadItem(props: Props) {
     return (
         <div className={_cs(className, styles.uploadItem)}>
             <ElementFragments
-                icons={iconMap[data.fileType]}
+                icons={pending ? <Spinner /> : iconMap[data.fileType]}
                 iconsContainerClassName={styles.icons}
                 actions={hasFailed && (
                     <QuickActionButton

--- a/app/views/Project/Tagging/Sources/BulkUpload/index.tsx
+++ b/app/views/Project/Tagging/Sources/BulkUpload/index.tsx
@@ -165,6 +165,10 @@ function BulkUpload(props: Props) {
                 );
             }
 
+            // set first failed lead as selected
+            // we will remove all successful leads
+            setSelectedLead(failedLeads[0]?.clientId);
+
             reset();
         },
         [inspect, reset, alert, setFormError, setFormFieldValue],
@@ -298,7 +302,7 @@ function BulkUpload(props: Props) {
                 formValidate,
                 setFormError,
                 (value) => {
-                    // FIXME: do not send leads with error
+                    // FIXME: send request even if there are errors on some requests
                     const leadsWithoutError = value.leads ?? [];
 
                     init(
@@ -307,6 +311,7 @@ function BulkUpload(props: Props) {
                     );
 
                     const initialLeads = pop();
+                    console.warn(initialLeads);
 
                     if (initialLeads.length <= 0) {
                         return;

--- a/app/views/Project/Tagging/Sources/BulkUpload/styles.css
+++ b/app/views/Project/Tagging/Sources/BulkUpload/styles.css
@@ -1,6 +1,7 @@
 .bulk-upload-modal {
     .modal-body {
         display: flex;
+        position: relative;
 
         .upload {
             display: flex;

--- a/app/views/Project/Tagging/Sources/LeadEditModal/index.tsx
+++ b/app/views/Project/Tagging/Sources/LeadEditModal/index.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useMemo, useCallback, useState } from 'react';
 import {
     _cs,
     randomString,
+    isDefined,
 } from '@togglecorp/fujs';
 import {
     Card,
@@ -16,6 +17,7 @@ import {
     internal,
     SetValueArg,
 } from '@togglecorp/toggle-form';
+import { getOperationName } from 'apollo-link';
 import { useMutation, useQuery, gql } from '@apollo/client';
 
 import LeadPreview from '#components/lead/LeadPreview';
@@ -34,6 +36,8 @@ import {
 } from '#generated/types';
 import { ProjectContext } from '#base/context/ProjectContext';
 import { UserContext } from '#base/context/UserContext';
+
+import { PROJECT_SOURCES } from '#views/Project/Tagging/Sources/SourcesTable/queries';
 import { BasicOrganization } from '#components/selections/NewOrganizationSelectInput';
 import { BasicProjectUser } from '#components/selections/ProjectUserSelectInput';
 import { BasicLeadGroup } from '#components/selections/LeadGroupSelectInput';
@@ -351,7 +355,7 @@ function LeadEditModal(props: Props) {
     ] = useMutation<LeadUpdateMutation, LeadUpdateMutationVariables>(
         LEAD_UPDATE,
         {
-            refetchQueries: ['ProjectSources'],
+            refetchQueries: [getOperationName(PROJECT_SOURCES)].filter(isDefined),
             onCompleted: (response) => {
                 if (!response?.project?.leadUpdate) {
                     return;
@@ -391,7 +395,7 @@ function LeadEditModal(props: Props) {
     ] = useMutation<LeadCreateMutation, LeadCreateMutationVariables>(
         LEAD_CREATE,
         {
-            refetchQueries: ['ProjectSources'],
+            refetchQueries: [getOperationName(PROJECT_SOURCES)].filter(isDefined),
             onCompleted: (response) => {
                 if (!response?.project?.leadCreate) {
                     return;

--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -63,6 +63,7 @@ import LeadEditModal from '../LeadEditModal';
 import BulkActions from './BulkActions';
 import EntryList from './EntryList';
 
+import { PROJECT_SOURCES } from './queries';
 import styles from './styles.css';
 
 function sourcesKeySelector(d: Lead) {
@@ -85,120 +86,6 @@ const defaultSorting = {
     name: 'CREATED_AT',
     direction: 'Descending',
 };
-
-export const PROJECT_SOURCES = gql`
-    query ProjectSources(
-        $projectId: ID!,
-        $page: Int,
-        $pageSize: Int,
-        $ordering: [LeadOrderingEnum!],
-        $assignees: [ID!],
-        $authoringOrganizationTypes: [ID!],
-        $confidentiality: LeadConfidentialityEnum,
-        $createdAtGte: DateTime,
-        $createdAtLte: DateTime,
-        $emmEntities: String,
-        $emmKeywords: String,
-        $emmRiskFactors: String,
-        $exists: LeadExistsEnum,
-        $priorities: [LeadPriorityEnum!],
-        $publishedOnGte: Date,
-        $publishedOnLte: Date,
-        $search: String,
-        $statuses: [LeadStatusEnum!],
-        $sourceOrganizations: [ID!],
-        $authorOrganizations: [ID!],
-        $entriesFilterData: LeadEntriesFilterData,
-        $customFilters: LeadCustomFilterEnum,
-    ) {
-        project(id: $projectId) {
-            id
-            leads (
-                page: $page,
-                pageSize: $pageSize,
-                ordering: $ordering,
-                assignees: $assignees,
-                authoringOrganizationTypes: $authoringOrganizationTypes,
-                confidentiality: $confidentiality,
-                createdAtGte: $createdAtGte,
-                createdAtLte: $createdAtLte,
-                emmEntities: $emmEntities,
-                emmKeywords: $emmKeywords,
-                emmRiskFactors: $emmRiskFactors,
-                exists: $exists,
-                priorities: $priorities,
-                publishedOnGte: $publishedOnGte,
-                publishedOnLte: $publishedOnLte,
-                search: $search,
-                statuses: $statuses,
-                sourceOrganizations: $sourceOrganizations,
-                authorOrganizations: $authorOrganizations,
-                entriesFilterData: $entriesFilterData,
-                customFilters: $customFilters,
-            ) {
-                totalCount
-                page
-                pageSize
-                results {
-                    id
-                    confidentiality
-                    clientId
-                    status
-                    statusDisplay
-                    createdAt
-                    title
-                    publishedOn
-                    priority
-                    priorityDisplay
-                    url
-                    attachment {
-                        id
-                        title
-                        mimeType
-                        file {
-                            url
-                        }
-                    }
-                    assessmentId
-                    createdBy {
-                        id
-                        displayName
-                    }
-                    project
-                    authors {
-                        id
-                        title
-                        mergedAs {
-                            id
-                            title
-                        }
-                    }
-                    assignee {
-                        id
-                        displayName
-                    }
-                    source {
-                        mergedAs {
-                            id
-                            title
-                        }
-                        id
-                        url
-                        title
-                    }
-                    entriesCounts {
-                        controlled
-                        total
-                    }
-                    leadPreview {
-                        pageCount
-                    }
-                    isAssessmentLead
-                }
-            }
-        }
-    }
-`;
 
 interface SourceLinkProps {
     title?: string;

--- a/app/views/Project/Tagging/Sources/SourcesTable/queries.ts
+++ b/app/views/Project/Tagging/Sources/SourcesTable/queries.ts
@@ -1,0 +1,116 @@
+import { gql } from '@apollo/client';
+
+// eslint-disable-next-line import/prefer-default-export
+export const PROJECT_SOURCES = gql`
+    query ProjectSources(
+        $projectId: ID!,
+        $page: Int,
+        $pageSize: Int,
+        $ordering: [LeadOrderingEnum!],
+        $assignees: [ID!],
+        $authoringOrganizationTypes: [ID!],
+        $confidentiality: LeadConfidentialityEnum,
+        $createdAtGte: DateTime,
+        $createdAtLte: DateTime,
+        $emmEntities: String,
+        $emmKeywords: String,
+        $emmRiskFactors: String,
+        $exists: LeadExistsEnum,
+        $priorities: [LeadPriorityEnum!],
+        $publishedOnGte: Date,
+        $publishedOnLte: Date,
+        $search: String,
+        $statuses: [LeadStatusEnum!],
+        $sourceOrganizations: [ID!],
+        $authorOrganizations: [ID!],
+        $entriesFilterData: LeadEntriesFilterData,
+        $customFilters: LeadCustomFilterEnum,
+    ) {
+        project(id: $projectId) {
+            id
+            leads (
+                page: $page,
+                pageSize: $pageSize,
+                ordering: $ordering,
+                assignees: $assignees,
+                authoringOrganizationTypes: $authoringOrganizationTypes,
+                confidentiality: $confidentiality,
+                createdAtGte: $createdAtGte,
+                createdAtLte: $createdAtLte,
+                emmEntities: $emmEntities,
+                emmKeywords: $emmKeywords,
+                emmRiskFactors: $emmRiskFactors,
+                exists: $exists,
+                priorities: $priorities,
+                publishedOnGte: $publishedOnGte,
+                publishedOnLte: $publishedOnLte,
+                search: $search,
+                statuses: $statuses,
+                sourceOrganizations: $sourceOrganizations,
+                authorOrganizations: $authorOrganizations,
+                entriesFilterData: $entriesFilterData,
+                customFilters: $customFilters,
+            ) {
+                totalCount
+                page
+                pageSize
+                results {
+                    id
+                    confidentiality
+                    clientId
+                    status
+                    statusDisplay
+                    createdAt
+                    title
+                    publishedOn
+                    priority
+                    priorityDisplay
+                    url
+                    attachment {
+                        id
+                        title
+                        mimeType
+                        file {
+                            url
+                        }
+                    }
+                    assessmentId
+                    createdBy {
+                        id
+                        displayName
+                    }
+                    project
+                    authors {
+                        id
+                        title
+                        mergedAs {
+                            id
+                            title
+                        }
+                    }
+                    assignee {
+                        id
+                        displayName
+                    }
+                    source {
+                        mergedAs {
+                            id
+                            title
+                        }
+                        id
+                        url
+                        title
+                    }
+                    entriesCounts {
+                        controlled
+                        total
+                    }
+                    leadPreview {
+                        pageCount
+                    }
+                    isAssessmentLead
+                }
+            }
+        }
+    }
+`;

--- a/app/views/Project/Tagging/Sources/components/EditableEntry/index.tsx
+++ b/app/views/Project/Tagging/Sources/components/EditableEntry/index.tsx
@@ -9,6 +9,7 @@ import {
     generatePath,
 } from 'react-router-dom';
 import { gql, useMutation } from '@apollo/client';
+import { getOperationName } from 'apollo-link';
 import {
     isDefined,
     listToMap,
@@ -25,6 +26,7 @@ import {
 import { FiEdit2 } from 'react-icons/fi';
 import { IoTrash } from 'react-icons/io5';
 
+import { PROJECT_SOURCES } from '#views/Project/Tagging/Sources/SourcesTable/queries';
 import {
     getEntrySchema,
     PartialEntryType as EntryInputType,
@@ -160,7 +162,7 @@ function EditableEntry(props: Props) {
     ] = useMutation<UpdateEntryMutation, UpdateEntryMutationVariables>(
         UPDATE_ENTRY,
         {
-            refetchQueries: ['ProjectSources'],
+            refetchQueries: [getOperationName(PROJECT_SOURCES)].filter(isDefined),
             onCompleted: (gqlResponse) => {
                 const response = gqlResponse?.project?.entryUpdate;
                 if (!response) {
@@ -204,7 +206,7 @@ function EditableEntry(props: Props) {
     ] = useMutation(
         DELETE_ENTRY,
         {
-            refetchQueries: ['ProjectSources'],
+            refetchQueries: [getOperationName(PROJECT_SOURCES)].filter(isDefined),
             onCompleted: (response) => {
                 const {
                     ok,


### PR DESCRIPTION
## Changes

- Leads will be saved on a batch of N leads. (N = 2 for ease of testing)
- If an error occurs that cannot be retried, no other batches will be processed and the UI will reflect completed batches.
- Leads table will be re-fetched only at the end of all batches.

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations
