### PR TITLE
Add button to trigger pdf cache in html proxy server

### DIFF
--- a/app/Base/configs/env.ts
+++ b/app/Base/configs/env.ts
@@ -11,6 +11,8 @@ export const apiHttps = process.env.REACT_APP_API_HTTPS || 'http';
 export const apiEndpoint = process.env.REACT_APP_API_END as string; // localhost:8000
 export const graphqlEndpoint = process.env.REACT_APP_GRAPHQL_ENDPOINT as string; // http://localhost:8000/graphql
 export const serverlessEndpoint = process.env.REACT_APP_SERVERLESS_DOMAIN || 'https://services-local.thedeep.io';
+// eslint-disable-next-line max-len
+export const pdfCacheEndpoint = process.env.REACT_APP_PDF_CACHE_ENDPOINT as string; // localhost:8081
 
 // Iframes
 export const oldAryEndpoint = process.env.REACT_APP_ASSESSMENT_REGISTRY_END; // http://localhost:3100

--- a/app/Base/configs/restRequest.ts
+++ b/app/Base/configs/restRequest.ts
@@ -1,6 +1,7 @@
 import {
     apiEndpoint,
     serverlessEndpoint as serverlessEndpointFromEnv,
+    pdfCacheEndpoint as pdfCacheEndpointFromEnv,
     apiHttps,
 } from '#base/configs/env';
 
@@ -17,3 +18,4 @@ export const adminEndpoint = !apiEndpoint
     : `${reactAppApiHttps}://${apiEndpoint}/admin/`;
 
 export const serverlessEndpoint = serverlessEndpointFromEnv;
+export const pdfCacheEndpoint = pdfCacheEndpointFromEnv;

--- a/app/Base/utils/restRequest.ts
+++ b/app/Base/utils/restRequest.ts
@@ -10,6 +10,7 @@ import { AlertOptions } from '@the-deep/deep-ui';
 import { mapToMap, isDefined, randomString } from '@togglecorp/fujs';
 import {
     serverlessEndpoint,
+    pdfCacheEndpoint,
     wsEndpoint,
     // reactAppApiHttps,
 } from '#base/configs/restRequest';
@@ -107,6 +108,7 @@ export type DeepContextInterface = ContextInterface<
 
 const serverPrefix = 'server://';
 const serverlessPrefix = 'serverless://';
+const pdfCachePrefix = 'pdf-cache://';
 export const processDeepUrls: DeepContextInterface['transformUrl'] = (url) => {
     if (url.startsWith(serverPrefix)) {
         // NOTE: -1 to leave out the starting slash
@@ -117,6 +119,11 @@ export const processDeepUrls: DeepContextInterface['transformUrl'] = (url) => {
         // NOTE: -1 to leave out the starting slash
         const cleanedUrl = url.slice(serverlessPrefix.length - 1);
         return `${serverlessEndpoint}${cleanedUrl}`;
+    }
+    if (url.startsWith(pdfCachePrefix)) {
+        // NOTE: -1 to leave out the starting slash
+        const cleanedUrl = url.slice(pdfCachePrefix.length - 1);
+        return `${pdfCacheEndpoint}${cleanedUrl}`;
     }
     if (/^https?:\/\//i.test(url)) {
         return url;


### PR DESCRIPTION
- Poll proxy server to get pdf cache


## Special Treatment

- We will need to pass a environment variable REACT_APP_HTML_PROXY_ENDPOINT
- We should also be running this service https://github.com/toggle-corp/pdf-my-html

## This PR doesn't introduce any:

- [ ] temporary files, auto-generated files or secret keys
- [ ] build works
- [ ] eslint issues
- [ ] typescript issues
- [ ] codegen errors
- [ ] `console.log` meant for debugging
- [ ] typos
- [ ] unwanted comments
- [ ] conflict markers

## This PR contains valid:

- [ ] permission checks
- [ ] translations
