### PR TITLE
Use prefix `auto-` for objects created using autovivification

### DIFF
--- a/app/components/entry/EntryInput/index.tsx
+++ b/app/components/entry/EntryInput/index.tsx
@@ -98,7 +98,7 @@ function EntryInput<T extends string | number | undefined>(props: EntryInputProp
 
     const defaultOptionVal = useCallback(
         (): PartialEntryType => ({
-            clientId: randomString(),
+            clientId: `auto-${randomString()}`,
             entryType: 'EXCERPT',
             lead: leadId,
             excerpt: '',

--- a/app/components/framework/AttributeInput/index.tsx
+++ b/app/components/framework/AttributeInput/index.tsx
@@ -99,7 +99,7 @@ function AttributeInput<N extends string | number | undefined>(props: Props<N>) 
 
     const defaultOptionVal = useCallback(
         (): PartialAttributeType => ({
-            clientId: randomString(),
+            clientId: `auto-${randomString()}`,
             widgetType: widget.widgetId,
             // NOTE: widget.id should always be defined before an attribute can be saved
             widget: widget.id ?? 'not-random',

--- a/app/components/framework/CompactAttributeInput/index.tsx
+++ b/app/components/framework/CompactAttributeInput/index.tsx
@@ -116,7 +116,7 @@ function CompactAttributeInput<N extends string | number | undefined>(props: Pro
 
     const defaultOptionVal = useCallback(
         (): PartialAttributeType => ({
-            clientId: randomString(),
+            clientId: `auto-${randomString()}`,
             widgetType: widget.widgetId,
             // NOTE: widget.id should always be defined before an attribute can be saved
             widget: widget.id ?? 'not-random',

--- a/app/views/AnalyticalFramework/PrimaryTagging/SectionsEditor/index.tsx
+++ b/app/views/AnalyticalFramework/PrimaryTagging/SectionsEditor/index.tsx
@@ -93,7 +93,7 @@ const schema: FormSchema = {
 };
 
 const defaultVal = (): PartialSectionType => ({
-    clientId: randomString(),
+    clientId: `auto-${randomString()}`,
     order: -1,
 });
 

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateConditionalWidgetForm/SimpleDateConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateConditionalWidgetForm/SimpleDateConditionInput/index.tsx
@@ -32,7 +32,7 @@ interface TextContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateConditionalWidgetForm/index.tsx
@@ -149,7 +149,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -197,7 +197,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateRangeConditionalWidgetForm/SimpleDateRangeConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateRangeConditionalWidgetForm/SimpleDateRangeConditionInput/index.tsx
@@ -32,7 +32,7 @@ interface TextContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateRangeConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/DateRangeConditionalWidgetForm/index.tsx
@@ -149,7 +149,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -197,7 +197,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/GeoLocationConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/GeoLocationConditionalWidgetForm/index.tsx
@@ -120,7 +120,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -168,7 +168,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix1dConditionalWidgetForm/SimpleMatrix1dConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix1dConditionalWidgetForm/SimpleMatrix1dConditionInput/index.tsx
@@ -37,7 +37,7 @@ interface Matrix1dContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix1dConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix1dConditionalWidgetForm/index.tsx
@@ -149,7 +149,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -199,7 +199,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix2dConditionalWidgetForm/SimpleMatrix2dConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix2dConditionalWidgetForm/SimpleMatrix2dConditionInput/index.tsx
@@ -40,7 +40,7 @@ interface Matrix2dContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix2dConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/Matrix2dConditionalWidgetForm/index.tsx
@@ -156,7 +156,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -206,7 +206,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/MultiSelectConditionalWidgetForm/SimpleMultiSelectConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/MultiSelectConditionalWidgetForm/SimpleMultiSelectConditionInput/index.tsx
@@ -35,7 +35,7 @@ interface MultiSelectContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/MultiSelectConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/MultiSelectConditionalWidgetForm/index.tsx
@@ -146,7 +146,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -196,7 +196,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/NumberConditionalWidgetForm/SimpleNumberConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/NumberConditionalWidgetForm/SimpleNumberConditionInput/index.tsx
@@ -32,7 +32,7 @@ interface TextContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/NumberConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/NumberConditionalWidgetForm/index.tsx
@@ -150,7 +150,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -198,7 +198,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/OrganigramConditionalWidgetForm/SimpleOrganigramConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/OrganigramConditionalWidgetForm/SimpleOrganigramConditionInput/index.tsx
@@ -38,7 +38,7 @@ interface OrganigramContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/OrganigramConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/OrganigramConditionalWidgetForm/index.tsx
@@ -146,7 +146,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -196,7 +196,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/ScaleConditionalWidgetForm/SimpleScaleConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/ScaleConditionalWidgetForm/SimpleScaleConditionInput/index.tsx
@@ -34,7 +34,7 @@ interface ScaleContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/ScaleConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/ScaleConditionalWidgetForm/index.tsx
@@ -145,7 +145,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -195,7 +195,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/SingleSelectConditionalWidgetForm/SimpleSingleSelectConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/SingleSelectConditionalWidgetForm/SimpleSingleSelectConditionInput/index.tsx
@@ -34,7 +34,7 @@ interface SingleSelectContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/SingleSelectConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/SingleSelectConditionalWidgetForm/index.tsx
@@ -145,7 +145,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -195,7 +195,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TextConditionalWidgetForm/SimpleTextConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TextConditionalWidgetForm/SimpleTextConditionInput/index.tsx
@@ -32,7 +32,7 @@ interface TextContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TextConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TextConditionalWidgetForm/index.tsx
@@ -149,7 +149,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -197,7 +197,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeConditionalWidgetForm/SimpleTimeConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeConditionalWidgetForm/SimpleTimeConditionInput/index.tsx
@@ -32,7 +32,7 @@ interface TextContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeConditionalWidgetForm/index.tsx
@@ -149,7 +149,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -197,7 +197,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeRangeConditionalWidgetForm/SimpleTimeRangeConditionInput/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeRangeConditionalWidgetForm/SimpleTimeRangeConditionInput/index.tsx
@@ -32,7 +32,7 @@ interface TextContainsConditionInputProps {
 }
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',

--- a/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeRangeConditionalWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetConditionalEditor/TimeRangeConditionalWidgetForm/index.tsx
@@ -149,7 +149,7 @@ const schema: FormSchema = {
 const conditionKeySelector = (o: PartialConditionType) => o.key;
 
 const defaultConditionVal = (): PartialConditionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 
     conjunctionOperator: 'AND',
@@ -197,7 +197,7 @@ function ConditionInput(props: ConditionInputProps) {
                     // eslint-disable-next-line no-console
                     console.error('Trying to change operator when no value is defined');
                     return {
-                        key: randomString(),
+                        key: `auto-${randomString()}`,
                         order: -1,
                         conjunctionOperator: 'AND',
                         invert: false,

--- a/app/views/AnalyticalFramework/components/WidgetEditor/Matrix1dWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetEditor/Matrix1dWidgetForm/index.tsx
@@ -141,7 +141,7 @@ const schema: FormSchema = {
 };
 
 const defaultCellVal = (): PartialCellType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 
@@ -244,7 +244,7 @@ function CellInput(props: CellInputProps) {
 }
 
 const defaultRowVal = (): PartialRowType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 interface RowInputProps {

--- a/app/views/AnalyticalFramework/components/WidgetEditor/Matrix2dWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetEditor/Matrix2dWidgetForm/index.tsx
@@ -213,7 +213,7 @@ const schema: FormSchema = {
 };
 
 const defaultSubRowVal = (): PartialSubRowType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 interface SubRowInputProps {
@@ -311,7 +311,7 @@ function SubRowInput(props: SubRowInputProps) {
 }
 
 const defaultRowVal = (): PartialRowType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 interface RowInputProps {
@@ -369,6 +369,7 @@ function RowInput(props: RowInputProps) {
                 key,
                 order: oldSubRows.length + 1,
             };
+            // FIXME: this may be problematic, why not use the function api to do this?
             onFieldChange(
                 [...reorder(oldSubRows), newSubRow],
                 'subRows' as const,
@@ -506,7 +507,7 @@ function RowInput(props: RowInputProps) {
 }
 
 const defaultSubColumnVal = (): PartialSubColumnType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 interface SubColumnInputProps {
@@ -604,7 +605,7 @@ function SubColumnInput(props: SubColumnInputProps) {
 }
 
 const defaultColumnVal = (): PartialColumnType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 interface ColumnInputProps {

--- a/app/views/AnalyticalFramework/components/WidgetEditor/MultiSelectWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetEditor/MultiSelectWidgetForm/index.tsx
@@ -108,7 +108,7 @@ const schema: FormSchema = {
 };
 
 const defaultOptionVal = (): PartialOptionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 

--- a/app/views/AnalyticalFramework/components/WidgetEditor/OrganigramWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetEditor/OrganigramWidgetForm/index.tsx
@@ -97,7 +97,7 @@ const schema: FormSchema = {
     }),
 };
 const defaultNodeVal = (): PartialNodeType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 
@@ -283,7 +283,7 @@ function NodeInput(props: NodeInputProps) {
     );
 }
 const defaultRootVal = (): PartialRootType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 

--- a/app/views/AnalyticalFramework/components/WidgetEditor/ScaleWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetEditor/ScaleWidgetForm/index.tsx
@@ -112,7 +112,7 @@ const schema: FormSchema = {
 };
 
 const defaultOptionVal = (): PartialOptionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 

--- a/app/views/AnalyticalFramework/components/WidgetEditor/SingleSelectWidgetForm/index.tsx
+++ b/app/views/AnalyticalFramework/components/WidgetEditor/SingleSelectWidgetForm/index.tsx
@@ -108,7 +108,7 @@ const schema: FormSchema = {
 };
 
 const defaultOptionVal = (): PartialOptionType => ({
-    key: randomString(),
+    key: `auto-${randomString()}`,
     order: -1,
 });
 

--- a/app/views/Project/EntryEdit/index.tsx
+++ b/app/views/Project/EntryEdit/index.tsx
@@ -197,9 +197,11 @@ function EntryEdit(props: Props) {
 
     const [selectedEntry, setSelectedEntry] = useState<string | undefined>(undefined);
 
+    // NOTE: Using useCallback because this needs to be called everytime to get
+    // new clientId
     const defaultOptionVal = useCallback(
         (): PartialEntryType => ({
-            clientId: randomString(),
+            clientId: `auto-${randomString()}`,
             entryType: 'EXCERPT',
             lead: leadId,
             excerpt: '',
@@ -817,10 +819,12 @@ function EntryEdit(props: Props) {
         setSelectedEntry(entryId);
     }, [createRestorePoint]);
 
+    // FIXME: check if we need to do this? also memoize this?
     const currentEntryIndex = formValue.entries?.findIndex(
         (entry) => entry.clientId === selectedEntry,
     ) ?? -1;
 
+    // FIXME: check if we need to do this?
     const currentEntry = formValue.entries?.[currentEntryIndex];
 
     const entriesError = useMemo(
@@ -954,12 +958,14 @@ function EntryEdit(props: Props) {
         [restore],
     );
 
+    // FIXME: check if we need to do this?
     const onEntryFieldChange = useFormObject(
         currentEntryIndex === -1 ? undefined : currentEntryIndex,
         handleEntryChange,
         defaultOptionVal,
     );
 
+    // FIXME: check if we need to do this?
     const handleExcerptChange = useCallback(
         (_: string, excerpt: string | undefined) => {
             onEntryFieldChange(excerpt, 'excerpt');
@@ -967,8 +973,10 @@ function EntryEdit(props: Props) {
         [onEntryFieldChange],
     );
 
+    // FIXME: check if we need to do this?
     const handleEntryDelete = useCallback(
         () => {
+            // NOTE: add note why we are clearing restore point
             clearRestorePoint();
             onEntryFieldChange(true, 'deleted');
             setSelectedEntry(undefined);
@@ -976,8 +984,10 @@ function EntryEdit(props: Props) {
         [onEntryFieldChange, clearRestorePoint],
     );
 
+    // FIXME: check if we need to do this?
     const handleEntryRestore = useCallback(
         () => {
+            // NOTE: add note why we are clearing restore point
             clearRestorePoint();
             onEntryFieldChange(false, 'deleted');
             setSelectedEntry(undefined);
@@ -1532,6 +1542,7 @@ function EntryEdit(props: Props) {
                                         onEntryCreate={handleEntryCreate}
                                         onEntryDelete={handleEntryDelete}
                                         onEntryRestore={handleEntryRestore}
+                                        // FIXME: maybe move the entries change inside
                                         onExcerptChange={handleExcerptChange}
                                         onApproveButtonClick={handleEntryChangeApprove}
                                         onDiscardButtonClick={handleEntryChangeDiscard}

--- a/app/views/Project/PillarAnalysis/AnalyticalStatementInput/index.tsx
+++ b/app/views/Project/PillarAnalysis/AnalyticalStatementInput/index.tsx
@@ -65,7 +65,7 @@ export interface AnalyticalStatementInputProps {
 }
 
 const defaultVal = (): AnalyticalStatementType => ({
-    clientId: randomString(),
+    clientId: `auto-${randomString()}`,
     analyticalEntries: [],
 });
 

--- a/app/views/Project/Tagging/Sources/LeadEditModal/index.tsx
+++ b/app/views/Project/Tagging/Sources/LeadEditModal/index.tsx
@@ -240,7 +240,7 @@ function LeadEditModal(props: Props) {
     const { user } = useContext(UserContext);
 
     const initialValue: PartialFormType = useMemo(() => ({
-        clientId: randomString(),
+        clientId: `auto-${randomString()}`,
         sourceType: 'WEBSITE',
         priority: 'LOW',
         confidentiality: 'UNPROTECTED',


### PR DESCRIPTION
- We need a way to differentiate between object created explicitly and
  non-explicitly to debug duplicate objects problem

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations
