### PR TITLE
Add mime type to public lead attachment

### DIFF
--- a/app/views/DocumentViewer/index.tsx
+++ b/app/views/DocumentViewer/index.tsx
@@ -34,10 +34,19 @@ import ProjectJoinModal from '#views/ExploreDeep/ActionCell/ProjectJoinModal';
 
 import {
     PublicLeadQuery,
+    LeadSourceTypeEnum,
     PublicLeadQueryVariables,
 } from '#generated/types';
 
 import styles from './styles.css';
+
+function isWebsiteType(sourceType: LeadSourceTypeEnum) {
+    return sourceType === 'WEBSITE' || sourceType === 'RSS' || sourceType === 'EMM' || sourceType === 'WEB_API';
+}
+
+function isAttachmentType(sourceType: LeadSourceTypeEnum) {
+    return sourceType === 'DISK' || sourceType === 'DROPBOX' || sourceType === 'GOOGLE_DRIVE';
+}
 
 const PUBLIC_LEAD = gql`
     query PublicLead($uuid: UUID!) {
@@ -45,6 +54,7 @@ const PUBLIC_LEAD = gql`
             lead {
                 attachment {
                     title
+                    mimeType
                     file {
                         name
                         url
@@ -54,7 +64,6 @@ const PUBLIC_LEAD = gql`
                 publishedOn
                 sourceTitle
                 sourceType
-                sourceTypeDisplay
                 text
                 url
                 uuid
@@ -252,8 +261,14 @@ function DocumentViewer(props: Props) {
             >
                 <LeadPreview
                     className={styles.preview}
-                    url={publicLeadDetails?.url ?? undefined}
-                    attachment={publicLeadDetails?.attachment ?? undefined}
+                    url={
+                        isWebsiteType(publicLeadDetails?.sourceType)
+                            ? publicLeadDetails?.url : undefined
+                    }
+                    attachment={
+                        isAttachmentType(publicLeadDetails?.sourceType)
+                            ? publicLeadDetails?.attachment : undefined
+                    }
                     hideBar
                 />
             </div>


### PR DESCRIPTION
- Depends on https://github.com/the-deep/server/pull/1101

## Changes

* Add mime type to attachment

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations