### PR TITLE
Add status change option in source table

### DIFF
--- a/app/views/Project/Tagging/Sources/SourcesFilter/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesFilter/index.tsx
@@ -96,6 +96,7 @@ const SOURCE_FILTER_OPTIONS = gql`
                     properties
                     title
                     widgetType
+                    widgetKey
                 }
             }
        }

--- a/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
+++ b/app/views/Project/Tagging/Sources/SourcesTable/index.tsx
@@ -436,6 +436,8 @@ function SourcesTable(props: Props) {
                 filteredEntriesCount: data.filteredEntriesCount,
                 hasAssessment: !!data.assessmentId,
                 isAssessmentLead: data.isAssessmentLead,
+                sourceStatus: data.status,
+                projectId,
             }),
             columnWidth: 196,
         };
@@ -522,6 +524,7 @@ function SourcesTable(props: Props) {
         selectedLeads,
         handleEdit,
         handleDelete,
+        projectId,
     ]);
 
     const handleSourceSaveSuccess = useCallback(() => {


### PR DESCRIPTION
- Addresses #2506

## Changes

* Add ability to change lead status from leads table

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers