### PR TITLE
Add export button in framework in projectEdit page

### DIFF
--- a/app/views/ProjectEdit/Framework/FrameworkDetail/index.tsx
+++ b/app/views/ProjectEdit/Framework/FrameworkDetail/index.tsx
@@ -2,14 +2,18 @@ import React, { useMemo, useState, useCallback, useContext } from 'react';
 import {
     _cs,
     isNotDefined,
+    isDefined,
 } from '@togglecorp/fujs';
 import { generatePath } from 'react-router-dom';
 import { gql, useQuery } from '@apollo/client';
 import {
     IoCopyOutline,
     IoCheckmark,
+    IoDownloadOutline,
 } from 'react-icons/io5';
-import { FiEdit2 } from 'react-icons/fi';
+import {
+    FiEdit2,
+} from 'react-icons/fi';
 import {
     Card,
     Tabs,
@@ -73,6 +77,10 @@ const FRAMEWORK_DETAILS = gql`
             allowedPermissions
             createdBy {
                 displayName
+            }
+            export {
+                name
+                url
             }
             # NOTE: Does not need predictionTagsMapping from FrameworkResponse
             ...FrameworkResponse
@@ -138,6 +146,8 @@ function FrameworkDetail(props: Props) {
         [frameworkDetailsResponse],
     );
     const sections = frameworkDetails?.primaryTagging;
+
+    const exportLink = frameworkDetails?.export?.url;
 
     const {
         pending: projectPatchPending,
@@ -276,6 +286,15 @@ function FrameworkDetail(props: Props) {
                                     >
                                         {_ts('projectEdit', 'selectedFrameworkTagLabel')}
                                     </Tag>
+                                )}
+                                {isDefined(exportLink) && (
+                                    <QuickActionLink
+                                        to={exportLink}
+                                        variant="secondary"
+                                        title="Export framework"
+                                    >
+                                        <IoDownloadOutline />
+                                    </QuickActionLink>
                                 )}
                                 {canEditFramework && (
                                     <QuickActionLink

--- a/app/views/ProjectEdit/Framework/styles.css
+++ b/app/views/ProjectEdit/Framework/styles.css
@@ -45,9 +45,9 @@
                     border-bottom: var(--dui-width-separator-thin) solid var(--dui-color-separator);
                     background-color: var(--dui-color-background-information);
                     padding: var(--dui-spacing-small) var(--dui-spacing-medium);
-                    gap: var(--dui-spacing-small);
                     width: 100%;
                     text-align: left;
+                    gap: var(--dui-spacing-small);
 
                     .title {
                         font-weight: var(--dui-font-weight-bold);


### PR DESCRIPTION
## Depends on https://github.com/the-deep/server/pull/1188

## Changes

* Add export button in framework section of projectEdit page

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers
