### PR TITLE
Show sub sectors in matrix 2D in readOnly mode

### DIFF
--- a/app/components/framework/AttributeInput/Matrix2dWidgetInput/index.tsx
+++ b/app/components/framework/AttributeInput/Matrix2dWidgetInput/index.tsx
@@ -262,13 +262,13 @@ function Row(props: RowProps) {
                                     <th
                                         className={_cs(
                                             styles.tableHeader,
-                                            ((column.subColumns?.length ?? 0) > 0 && !readOnly)
+                                            ((column.subColumns?.length ?? 0) > 0)
                                                 && styles.clickable,
                                         )}
                                         key={column.key}
                                         title={column.tooltip}
                                         onClick={() => {
-                                            if ((column.subColumns?.length ?? 0) > 0 && !readOnly) {
+                                            if ((column.subColumns?.length ?? 0) > 0) {
                                                 onSelectedColumnKeyChange(column.key);
                                             }
                                         }}


### PR DESCRIPTION
- Addresses #2695 

## Changes

* Show sub-sectors in matrix 2D in readOnly mode

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

