### PR TITLE
Hide auto entries extraction button for assisted tagging disabled sources

### DIFF
--- a/app/views/EntryEdit/LeftPane/index.tsx
+++ b/app/views/EntryEdit/LeftPane/index.tsx
@@ -1,4 +1,11 @@
-import React, { useContext, useState, useMemo, useEffect, useCallback, useRef } from 'react';
+import React, {
+    useContext,
+    useState,
+    useMemo,
+    useEffect,
+    useCallback,
+    useRef,
+} from 'react';
 import {
     _cs,
     isNotDefined,
@@ -384,9 +391,6 @@ function LeftPane(props: Props) {
         setShowCanvasDrawModalTrue();
     }, [fullScreenMode, setShowCanvasDrawModalTrue, setShowScreenshotFalse]);
 
-    const isAutoExtractionCompatible = isDefined(leadPreview?.textExtractionId)
-        && leadPreviewData?.project?.lead?.confidentiality !== 'CONFIDENTIAL';
-
     const originalTabContent = (
         <Container
             elementRef={containerRef}
@@ -547,6 +551,10 @@ function LeftPane(props: Props) {
         && frameworkDetails?.assistedTaggingEnabled
         && (frameworkDetails?.predictionTagsMapping?.length ?? 0) > 0;
 
+    const isAutoExtractionCompatible = isDefined(leadPreview?.textExtractionId)
+        && leadPreviewData?.project?.lead?.confidentiality !== 'CONFIDENTIAL'
+        && assistedTaggingShown;
+
     const errorMessageForAutoExtraction = useMemo(() => {
         const isConfidential = lead?.confidentiality === 'CONFIDENTIAL';
         if (isAutoExtractionCompatible) {
@@ -607,7 +615,7 @@ function LeftPane(props: Props) {
                     >
                         <>
                             <div className={styles.simplifiedHeader}>
-                                {!isEntrySelectionActive && (
+                                {!isEntrySelectionActive && assistedTaggingShown && (
                                     <div className={styles.extraction}>
                                         <Button
                                             className={styles.autoEntriesButton}

--- a/app/views/EntryEdit/LeftPane/styles.css
+++ b/app/views/EntryEdit/LeftPane/styles.css
@@ -35,12 +35,13 @@
 
         .simplified-header {
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-end;
             gap: var(--dui-spacing-large);
 
             .extraction {
                 display: flex;
                 align-items: center;
+                flex-grow: 1;
                 gap: var(--dui-spacing-extra-small);
 
                 .auto-entries-button {


### PR DESCRIPTION
## Changes

* Hide auto entries extraction button for assisted tagging disabled sources

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

