### PR TITLE
Show cluster title on pillar analysis

### DIFF
--- a/app/views/PillarAnalysis/AnalyticalStatementInput/index.tsx
+++ b/app/views/PillarAnalysis/AnalyticalStatementInput/index.tsx
@@ -6,6 +6,7 @@ import {
     IoBarChartSharp,
     IoEyeOffOutline,
     IoEyeOutline,
+    IoInformationCircleOutline,
 } from 'react-icons/io5';
 import { GrDrag } from 'react-icons/gr';
 import { useParams } from 'react-router-dom';
@@ -26,6 +27,7 @@ import {
     QuickActionButton,
     QuickActionConfirmButton,
     useAlert,
+    Header,
 } from '@the-deep/deep-ui';
 import {
     useFormArray,
@@ -446,6 +448,21 @@ function AnalyticalStatementInput(props: AnalyticalStatementInputProps) {
                 headerDescriptionClassName={styles.headerDescription}
                 headerDescription={(
                     <>
+                        {isDefined(value.title) && (
+                            <Header
+                                heading={value.title}
+                                headingSize="extraSmall"
+                                spacing="none"
+                                headingClassName={styles.clusterHeading}
+                                headingSectionClassName={styles.clusterHeadingSection}
+                                icons={(
+                                    <IoInformationCircleOutline
+                                        className={styles.clusterInfoIcon}
+                                        title="This NLP model generated short topic generalizes the entries contained within this cluster."
+                                    />
+                                )}
+                            />
+                        )}
                         <NonFieldError error={error} />
                         {statementAndInfoGapsShown && (
                             <>

--- a/app/views/PillarAnalysis/AnalyticalStatementInput/styles.css
+++ b/app/views/PillarAnalysis/AnalyticalStatementInput/styles.css
@@ -18,11 +18,32 @@
     }
 
     .header-description {
-        padding: var(--dui-spacing-small) var(--dui-spacing-small) 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--dui-spacing-medium);
+        padding: var(--dui-spacing-large) var(--dui-spacing-small) 0;
 
         .statement {
             width: 100%;
             gap: var(--dui-width-separator-thin);
+        }
+
+        .cluster-heading {
+            font-size: var(--dui-font-size-medium);
+            font-weight: normal;
+        }
+
+        .cluster-heading-section {
+            display: flex;
+            align-items: center;
+            gap: var(--dui-spacing-small);
+
+            .cluster-info-icon {
+                /* NOTE: consistent icon size */
+                width: 1rem;
+                height: 1rem;
+                color: var(--dui-color-accent);
+            }
         }
     }
 

--- a/app/views/PillarAnalysis/AutoClustering/index.tsx
+++ b/app/views/PillarAnalysis/AutoClustering/index.tsx
@@ -38,7 +38,7 @@ import {
 
 import styles from './styles.css';
 
-const MIN_ENTRIES = 25;
+const MIN_ENTRIES = 5;
 
 const PILLAR_AUTO_CLUSTERING_RESULTS = gql`
     ${ENTRY_FRAGMENT}
@@ -53,6 +53,7 @@ const PILLAR_AUTO_CLUSTERING_RESULTS = gql`
                 status
                 clusters {
                     id
+                    title
                     entries {
                         ...EntryResponse
                         createdBy {
@@ -269,6 +270,7 @@ function AutoClustering(props: Props) {
                 reportText: '',
                 informationGaps: '',
                 clientId: randomString(),
+                title: cluster.title ?? undefined,
             }),
         ) ?? [];
         onStatementsFromClustersSet(newStatements);

--- a/app/views/PillarAnalysis/index.tsx
+++ b/app/views/PillarAnalysis/index.tsx
@@ -250,6 +250,7 @@ const PILLAR_ANALYSIS = gql`
             reportText
             informationGaps
             includeInReport
+            title
             entries {
                 id
                 clientId
@@ -881,6 +882,7 @@ function PillarAnalysis() {
                     const analyticalStatements: PartialAnalyticalStatementType[] = pillarResponse
                         .result?.statements?.map((statement) => ({
                             ...statement,
+                            title: statement.title ?? undefined,
                             entries: statement.entries?.map((statementEntry) => ({
                                 ...statementEntry,
                                 entry: statementEntry.entry.id,

--- a/app/views/PillarAnalysis/schema.ts
+++ b/app/views/PillarAnalysis/schema.ts
@@ -54,6 +54,7 @@ const analyticalStatementSchema: AnalyticalStatementSchema = {
         reportText: [],
         includeInReport: [requiredCondition],
         entries: analyticalEntriesSchema,
+        title: [],
     }),
 };
 


### PR DESCRIPTION
## Depends on

- https://github.com/the-deep/server/pull/1431

## Changes

* Save cluster title on update analysis mutation
* Show cluster title on pillar analysis statement as header

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations
