### PR TITLE
Use graphql mutation to clone analytical framework

### DIFF
--- a/app/views/ProjectEdit/Framework/FrameworkDetail/index.tsx
+++ b/app/views/ProjectEdit/Framework/FrameworkDetail/index.tsx
@@ -584,6 +584,7 @@ function FrameworkDetail(props: Props) {
             </Tabs>
             {frameworkCloneModalShown && (
                 <CloneFrameworkModal
+                    projectId={projectId}
                     frameworkToClone={frameworkId}
                     frameworkTitle={frameworkDetails?.title}
                     frameworkDescription={frameworkDetails?.description}


### PR DESCRIPTION
- Addresses https://github.com/the-deep/client/issues/2902
- Depends on https://github.com/the-deep/server/pull/1477

## Changes

* Use graphql mutation to clone a framework

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
- [x] translations
