### PR TITLE
Add info message for projects with no analysis framework

### DIFF
--- a/app/views/Sources/SourcesTable/Actions/index.tsx
+++ b/app/views/Sources/SourcesTable/Actions/index.tsx
@@ -5,6 +5,7 @@ import {
     IoChevronUpOutline,
     IoChevronDownOutline,
     IoWarningOutline,
+    IoInformation,
 } from 'react-icons/io5';
 import { _cs, isDefined } from '@togglecorp/fujs';
 import { MdModeEdit } from 'react-icons/md';
@@ -15,6 +16,7 @@ import {
     useConfirmation,
     Button,
     RowExpansionContext,
+    Tooltip,
     useModalState,
     useAlert,
 } from '@the-deep/deep-ui';
@@ -209,9 +211,22 @@ function Actions<T extends string>(props: Props<T>) {
         : entriesCount < 1;
     const noOfEntries = filteredEntriesCount ?? entriesCount;
 
+    const projectHasFramework = isDefined(project?.analysisFramework?.id);
+
     return (
         <div className={_cs(styles.actions, className)}>
             <div className={styles.row}>
+                {!projectHasFramework && (
+                    <div className={styles.info}>
+                        <IoInformation />
+                        <Tooltip>
+                            Looks like you have not chosen a framework for your project.
+                            Please edit your project or ask your admin to select a
+                            framework and start tagging.
+                        </Tooltip>
+                    </div>
+
+                )}
                 {canEditSource && (
                     <QuickActionButton
                         className={styles.button}

--- a/app/views/Sources/SourcesTable/Actions/styles.css
+++ b/app/views/Sources/SourcesTable/Actions/styles.css
@@ -12,6 +12,15 @@
         justify-content: flex-end;
         gap: var(--dui-spacing-small);
 
+        .info {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border: var(--dui-width-separator-thin) solid var(--dui-color-separator);
+            border-radius: 50%;
+            padding: var(--dui-spacing-extra-small);
+        }
+
         .button {
             flex-shrink: 0;
         }


### PR DESCRIPTION
- Addresses #2788 

## Changes

* Add note when no analytical framework is selected in a project (in the sources table)

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

