### PR TITLE
Use graphql to bulk delete leads

### DIFF
--- a/app/views/Sources/SourcesTable/BulkActions/index.tsx
+++ b/app/views/Sources/SourcesTable/BulkActions/index.tsx
@@ -24,7 +24,7 @@ interface Props {
     selectedLeads: Lead[];
     onClearSelection: () => void;
     activeProject: string;
-    onRemoveClick: (leadsToDelete: string[]) => void;
+    onRemoveClick: (selectedLeadIds: string[]) => void;
 }
 
 function BulkActions(props: Props) {
@@ -49,15 +49,16 @@ function BulkActions(props: Props) {
         selectedLeads.filter((lead) => isDefined(lead.assessmentId)).length
     ), [selectedLeads]);
 
-    const onRemoveBulkLead = useCallback(() => {
-        if (onRemoveClick) {
-            onRemoveClick(selectedLeads.map((lead) => lead.id));
-        }
-    }, [onRemoveClick, selectedLeads]);
-
     const selectedLeadsIds = useMemo(() => (
         selectedLeads.map((lead) => lead.id)
     ), [selectedLeads]);
+
+    const onRemoveBulkLead = useCallback(() => {
+        onRemoveClick(selectedLeadsIds);
+    }, [
+        onRemoveClick,
+        selectedLeadsIds,
+    ]);
 
     return (
         <div className={styles.bulkActionsBar}>


### PR DESCRIPTION
- Addresses #2989 
- Depends on https://github.com/the-deep/server/pull/1460

## Changes

* Implement GraphQl to bulk delete leads

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

## This PR contains valid:

- [x] permission checks
