### PR TITLE
Disable image zoom on scroll

### DIFF
--- a/app/components/entry/ExcerptInput/index.tsx
+++ b/app/components/entry/ExcerptInput/index.tsx
@@ -128,6 +128,7 @@ function ExcerptInput<N extends string>(props: Props<N>) {
                         className={_cs(imageClassName, styles.image)}
                         alt=""
                         src={attachmentSrc}
+                        disableZoomOnScroll
                     />
                 ) : (
                     <Message


### PR DESCRIPTION

## Changes

* Disable zoom in images during scroll in entry edit page

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] codegen errors
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments
- [x] conflict markers

